### PR TITLE
Handle Mono's .mdb debug symbols

### DIFF
--- a/src/Microsoft.NuGet.Build.Tasks/ResolveNuGetPackageAssets.cs
+++ b/src/Microsoft.NuGet.Build.Tasks/ResolveNuGetPackageAssets.cs
@@ -798,6 +798,19 @@ namespace Microsoft.NuGet.Build.Tasks
 
                         items.Add(pdbItem);
                     }
+
+                    // handle Mono mdb debug symbols
+                    var mdbFileName = item.ItemSpec + ".mdb";
+
+                    if (_fileExists(mdbFileName))
+                    {
+                        var mdbItem = new TaskItem(mdbFileName);
+
+                        // CopyMetadataTo also includes an OriginalItemSpec that will point to our original item, as we want
+                        item.CopyMetadataTo(mdbItem);
+
+                        items.Add(mdbItem);
+                    }
                 }
             }
 


### PR DESCRIPTION
If they're present copy them like their .pdb counterparts.
