### PR TITLE
Use Path.DirectorySeparatorChar instead of hardcoding backslash

### DIFF
--- a/src/Microsoft.NuGet.Build.Tasks/NuGetPackageObject.cs
+++ b/src/Microsoft.NuGet.Build.Tasks/NuGetPackageObject.cs
@@ -49,7 +49,7 @@ namespace Microsoft.NuGet.Build.Tasks
 
         public string GetFullPathToFile(string relativePath)
         {
-            relativePath = relativePath.Replace('/', '\\');
+            relativePath = relativePath.Replace('/', Path.DirectorySeparatorChar);
             return Path.Combine(_fullPackagePath.Value, relativePath);
         }
     }

--- a/src/Microsoft.NuGet.Build.Tasks/ResolveNuGetPackageAssets.cs
+++ b/src/Microsoft.NuGet.Build.Tasks/ResolveNuGetPackageAssets.cs
@@ -461,7 +461,7 @@ namespace Microsoft.NuGet.Build.Tasks
 
         private string GetPath(string packageName, string packageVersion, string file)
         {
-            return Path.Combine(GetNuGetPackagePath(packageName, packageVersion), file.Replace('/', '\\'));
+            return Path.Combine(GetNuGetPackagePath(packageName, packageVersion), file.Replace('/', Path.DirectorySeparatorChar));
         }
 
         /// <summary>
@@ -819,7 +819,7 @@ namespace Microsoft.NuGet.Build.Tasks
 
                 if (!string.IsNullOrEmpty(destinationSubDirectory))
                 {
-                    item.SetMetadata("DestinationSubDirectory", destinationSubDirectory + "\\");
+                    item.SetMetadata("DestinationSubDirectory", destinationSubDirectory + Path.DirectorySeparatorChar);
                 }
             }
 


### PR DESCRIPTION
This allows using the code on Unix filesystems that use forward slash.
