### PR TITLE
Exclude content files when reading project.assets.json

### DIFF
--- a/src/Microsoft.NuGet.Build.Tasks/Microsoft.NuGet.targets
+++ b/src/Microsoft.NuGet.Build.Tasks/Microsoft.NuGet.targets
@@ -15,27 +15,38 @@ Copyright (c) .NET Foundation. All rights reserved.
   <!-- Identify the assets file. -->
   <Choose>
     <When Condition="'$(ProjectLockFile)' != ''">
-      <!-- The ProjectLockFile has been specified; don't compute it. -->
+      <!-- The ProjectLockFile has been specified; don't compute it.
+           Create items for content files specified in the lock file. -->
+      <PropertyGroup>
+        <_CreateItemsForContentFiles>true</_CreateItemsForContentFiles>
+      </PropertyGroup>
     </When>
 
     <When Condition="Exists('$(MSBuildProjectName).project.json')">
-      <!-- There's a MyProj.project.json file, so use MyProj.project.lock.json. -->
+      <!-- There's a MyProj.project.json file, so use MyProj.project.lock.json.
+           Create items for content files specified in the MyProj.project.lock.json. -->
       <PropertyGroup>
         <ProjectLockFile>$(MSBuildProjectName).project.lock.json</ProjectLockFile>
+        <_CreateItemsForContentFiles>true</_CreateItemsForContentFiles>
       </PropertyGroup>
     </When>
 
     <When Condition="Exists('project.json')">
-      <!-- There's a project.json file, so use project.lock.json. -->
+      <!-- There's a project.json file, so use project.lock.json.
+           Create items for content files specified in the project.lock.json. -->
       <PropertyGroup>
         <ProjectLockFile>project.lock.json</ProjectLockFile>
+        <_CreateItemsForContentFiles>true</_CreateItemsForContentFiles>
       </PropertyGroup>
     </When>
 
     <Otherwise>
-      <!-- No project.json provided at all, so try to use the generated project.assets.json file.-->
+      <!-- No project.json provided at all, so try to use the generated project.assets.json file.
+           Don't create items for content files specified in project.assets.json. Package restore
+           will have already generated them into a .props file, so we shouldn't do it here. -->
       <PropertyGroup>
         <ProjectLockFile>$(BaseIntermediateOutputPath)project.assets.json</ProjectLockFile>
+        <_CreateItemsForContentFiles>false</_CreateItemsForContentFiles>
       </PropertyGroup>
     </Otherwise>
   </Choose>
@@ -205,7 +216,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <!-- The items in _NuGetContentItems need to go into the appropriately-named item group, but the names depend upon the items
          themselves. Split it apart. -->
-    <CreateItem Include="@(_NuGetContentItems)" Condition="'@(_NuGetContentItems)' != ''">
+    <CreateItem Include="@(_NuGetContentItems)" Condition="'@(_NuGetContentItems)' != '' and '$(_CreateItemsForContentFiles)' == 'true'">
       <Output TaskParameter="Include" ItemName="%(_NuGetContentItems.NuGetItemType)" />
     </CreateItem>
   </Target>


### PR DESCRIPTION
Among other things, the ResolveNuGetPackageAssets task reads entries from the "contentFiles" section of the assets file (i.e. project.lock.json or project.assets.json) and generates MSBuild items for them. We want to preserve this behavior for project.lock.json files, but when specifying packages with PackageReferences instead of a project.json file the items are placed into a generated .props file at restore time. We shouldn't create them again later.

The fix here is to simply drop the set of "ContentItems" returned from the task in case we're reading from a project.assets.json file.
