### PR TITLE
Fix IsFileValid() to use "cs" for file path comparisons

### DIFF
--- a/src/Microsoft.NuGet.Build.Tasks/ResolveNuGetPackageAssets.cs
+++ b/src/Microsoft.NuGet.Build.Tasks/ResolveNuGetPackageAssets.cs
@@ -465,7 +465,7 @@ namespace Microsoft.NuGet.Build.Tasks
             unExpectedLanguage = unExpectedLanguage == "C#" ? "cs" : unExpectedLanguage;
 
             return (ProjectLanguage.Equals(expectedProjectLanguage, StringComparison.OrdinalIgnoreCase)) &&
-                            (file.Split('/').Any(x => x.Equals(ProjectLanguage, StringComparison.OrdinalIgnoreCase)) ||
+                            (file.Split('/').Any(x => x.Equals(expectedLanguage, StringComparison.OrdinalIgnoreCase)) ||
                             !file.Split('/').Any(x => x.Equals(unExpectedLanguage, StringComparison.OrdinalIgnoreCase)));
         }
 


### PR DESCRIPTION
analyzer stuffs are located in analyzers/dotnet/cs/ or analyzers/dotnet/vb. 
the splited element should be compared with "expectedLanguage" variable. 