### PR TITLE
Fix finding packages in lower-case dirs on case-sensitive ..

### DIFF
--- a/src/Microsoft.NuGet.Build.Tasks/NuGetPackageObject.cs
+++ b/src/Microsoft.NuGet.Build.Tasks/NuGetPackageObject.cs
@@ -34,6 +34,7 @@ namespace Microsoft.NuGet.Build.Tasks
 
         public string Id { get; }
         public string Version { get; }
+        public string RelativePackagePath => (string)LibraryObject["path"];
         
         /// <summary>
         /// The JSON object from the "targets" section in the project.lock.json for this package.


### PR DESCRIPTION
.. filesystems.

NuGet now restores packages in lower case directory names, but the
build task `ResolveNuGetPackageAssets` constructs the path from package
name and version, like:

`Microsoft.NETCore.Portable.Compatibility/1.0.1`

.. instead of

`microsoft.netcore.portable.compatibility/1.0.1`

This breaks builds on msbuild/mono on case-sensitive filesystems, eg. on
Linux.

The actual on-disk path is available in the lock/assets.json file as:

```
"libraries": {
"Newtonsoft.Json/10.0.2": {
...
"path": "newtonsoft.json/10.0.2",
...
```

So, we use that to look for the package. But fallback to the old method if this
`"path"` is not available.

Cherry-picked 112685a925e5c0d26fcf9c9006341d4fa4f66515 from dev15.1 .