### PR TITLE
Populate ReferenceSatellitePaths with Resources

### DIFF
--- a/src/Microsoft.NuGet.Build.Tasks/Microsoft.NuGet.targets
+++ b/src/Microsoft.NuGet.Build.Tasks/Microsoft.NuGet.targets
@@ -218,6 +218,11 @@ Copyright (c) .NET Foundation. All rights reserved.
       <Reference Remove="%(_ReferencesFromNuGetPackages.FileName)" Condition="'%(_ReferencesFromNuGetPackages.NuGetIsFrameworkReference)' == 'false'"/>
     </ItemGroup>
 
+    <ItemGroup>
+      <!-- Add copy local references with a destination subdirectory to satellite references-->
+      <ReferenceSatellitePaths Include="@(ReferenceCopyLocalPaths)" Condition="'%(ReferenceCopyLocalPaths.DestinationSubDirectory)' != ''" />
+    </ItemGroup>
+
     <PropertyGroup Condition=" '$(AutoUnifyAssemblyReferences)' == 'true' ">
       <!-- Normally Design Time Assembly Resolution (DTAR) won't consider these references.
            Put DTAR in a mode where it will prefer the output of RAR and unify. -->


### PR DESCRIPTION
This is a proposed fix to missing satellite assemblies in the `SatelliteDllsProjectOutputGroupDependencies` when using PackageReference mode for NuGet dependencies ([Bug 465204](https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems/edit/465204))

Since I'm not familiar with how this was intended to work, here are some concerns I can think of:
- In the packages.config scenario, `ResolveAssemblyReferences` does this -- not clear why it is not doing so for this scenario. I tried removing `Private=false` from the Reference but that did not make a difference here.
- I thought about removing the items from `ReferenceSatellitePaths` before re-adding, to prevent duplicates, but its not clear how they could have gotten in there in the first place
- I see two separate code paths that create copy local items with `DestinationSubDirectory`: one is for [packages with locale information](https://github.com/NuGet/NuGet.BuildTasks/blob/18aedb7eb0fc26012246af61e4df7cda4ab10026/src/Microsoft.NuGet.Build.Tasks/ResolveNuGetPackageAssets.cs#L782), the other is for [copy-local items with an "outputPath"](https://github.com/NuGet/NuGet.BuildTasks/blob/18aedb7eb0fc26012246af61e4df7cda4ab10026/src/Microsoft.NuGet.Build.Tasks/ResolveNuGetPackageAssets.cs#L619). Should both be included in the satellite groups?
- The metadata included in the final outputgroup after using this approach is not exactly the same as the result of `ResolveAssemblyReferences` from packages.config scenario. Whether this is important depends on how consumers are using these output groups.
**from packages.config**
![image](https://user-images.githubusercontent.com/7732033/30508112-ec477152-9a43-11e7-9a9f-52d58ca1ed40.png)
**from PackageReference**
![image](https://user-images.githubusercontent.com/7732033/30508116-063d0720-9a44-11e7-8c58-c110e9968a3d.png)

/cc @rohit21agrawal @emgarten @jasonmalinowski @nguerrera 