### PR TITLE
Unblock PackageReference restore for *.vcxproj files

### DIFF
--- a/src/Microsoft.NuGet.Build.Tasks/Microsoft.NuGet.targets
+++ b/src/Microsoft.NuGet.Build.Tasks/Microsoft.NuGet.targets
@@ -68,7 +68,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   </PropertyGroup>
 
   <PropertyGroup>
-    <ResolveNuGetPackages Condition="'$(ResolveNuGetPackages)' == '' and '$(MSBuildProjectExtension)' != '.xproj'">true</ResolveNuGetPackages>
+    <ResolveNuGetPackages Condition="'$(ResolveNuGetPackages)' == '' and '$(MSBuildProjectExtension)' != '.xproj' and '$(MSBuildProjectExtension)' != '.vcxproj'">true</ResolveNuGetPackages>
 
     <!-- 
     if BaseNuGetRuntimeIdentifier is defined then simply use it as RuntimeIdentifier, otherwise


### PR DESCRIPTION
I have determined through manual testing that the ResolveNuGetPackageAssets task does not function under a *.vcxproj file, no matter what I try. Inspection of the task code reveals no indications of why it is failing. However, since this task is aimed towards restoring .NET assets, and that NuGet doesn't support .NET assets in C++/CLI projects anyway, this is not much of a loss. Skipping this task via setting `$(ResolveNuGetPackages)` to false allows the restore process to succeed.

Import of props/targets files in build/native folders of packages is not impacted by this change. This is especially important because the recommended/only way to do NuGet in a C++ project is to add props/targets files to the build using this method.