### PR TITLE
add C++ Project and C++ ARM/ARM64 Desktop application PackageReference support

### DIFF
--- a/src/Microsoft.NuGet.Build.Tasks/Microsoft.NuGet.targets
+++ b/src/Microsoft.NuGet.Build.Tasks/Microsoft.NuGet.targets
@@ -258,7 +258,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <!-- The items in _NuGetContentItems need to go into the appropriately-named item group, but the names depend upon the items
          themselves. Split it apart. -->
-    <CreateItem Include="@(_NuGetContentItems)" Condition="'@(_NuGetContentItems)' != ''">
+    <CreateItem Include="@(_NuGetContentItems)" AdditionalMetadata="PrecompiledHeader=NotUsing" Condition="'@(_NuGetContentItems)' != ''">
       <Output TaskParameter="Include" ItemName="%(_NuGetContentItems.NuGetItemType)" />
     </CreateItem>
   </Target>
@@ -334,7 +334,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <!-- The items in _NuGetContentItems need to go into the appropriately-named item group, but the names depend upon the items
          themselves. Split it apart. -->
-    <CreateItem Include="@(_NuGetContentItems)" Condition="'@(_NuGetContentItems)' != ''">
+    <CreateItem Include="@(_NuGetContentItems)" AdditionalMetadata="PrecompiledHeader=NotUsing" Condition="'@(_NuGetContentItems)' != ''">
       <Output TaskParameter="Include" ItemName="%(_NuGetContentItems.NuGetItemType)" />
     </CreateItem>
   </Target>

--- a/src/Microsoft.NuGet.Build.Tasks/Microsoft.NuGet.targets
+++ b/src/Microsoft.NuGet.Build.Tasks/Microsoft.NuGet.targets
@@ -80,7 +80,7 @@ Copyright (c) .NET Foundation. All rights reserved.
             <NuGetTargetMoniker Condition="'$(NuGetTargetMoniker)' == ''">native,Version=v14.2</NuGetTargetMoniker>
             <!--Compatible 2017 2015-->
             <_NuGetTargetFallbackMoniker>native,Version=v14.1;native,Version=v14.0;native,Version=v0.0</_NuGetTargetFallbackMoniker>
-            <TargetFrameworks Condition="'$(TargetFrameworks)' == ''">native14.2</TargetFrameworks>
+            <TargetFramework Condition="'$(TargetFramework)' == ''">native14.2</TargetFramework>
           </PropertyGroup>
         </When>
         <When Condition="'$(PlatformToolsetVersion)' == '141'">
@@ -89,7 +89,7 @@ Copyright (c) .NET Foundation. All rights reserved.
             <NuGetTargetMoniker Condition="'$(NuGetTargetMoniker)' == ''">native,Version=v14.1</NuGetTargetMoniker>
             <!--Compatible 2015-->
             <_NuGetTargetFallbackMoniker>native,Version=v14.0;native,Version=v0.0</_NuGetTargetFallbackMoniker>
-            <TargetFrameworks Condition="'$(TargetFrameworks)' == ''">native14.1</TargetFrameworks>
+            <TargetFramework Condition="'$(TargetFramework)' == ''">native14.1</TargetFramework>
           </PropertyGroup>
         </When>
         <When Condition="'$(PlatformToolsetVersion)' == '140'">
@@ -97,7 +97,7 @@ Copyright (c) .NET Foundation. All rights reserved.
           <PropertyGroup>
             <NuGetTargetMoniker Condition="'$(NuGetTargetMoniker)' == ''">native,Version=v14.0</NuGetTargetMoniker>
             <_NuGetTargetFallbackMoniker>native,Version=v0.0</_NuGetTargetFallbackMoniker>
-            <TargetFrameworks Condition="'$(TargetFrameworks)' == ''">native14.0</TargetFrameworks>
+            <TargetFramework Condition="'$(TargetFramework)' == ''">native14.0</TargetFramework>
           </PropertyGroup>
         </When>
         <When Condition="'$(PlatformToolsetVersion)' == '120'">
@@ -105,7 +105,7 @@ Copyright (c) .NET Foundation. All rights reserved.
           <PropertyGroup>
             <NuGetTargetMoniker Condition="'$(NuGetTargetMoniker)' == ''">native,Version=v12.0</NuGetTargetMoniker>
             <_NuGetTargetFallbackMoniker>native,Version=v0.0</_NuGetTargetFallbackMoniker>
-            <TargetFrameworks Condition="'$(TargetFrameworks)' == ''">native12.0</TargetFrameworks>
+            <TargetFramework Condition="'$(TargetFramework)' == ''">native12.0</TargetFramework>
           </PropertyGroup>
         </When>
         <When Condition="'$(PlatformToolsetVersion)' == '110'">
@@ -113,7 +113,7 @@ Copyright (c) .NET Foundation. All rights reserved.
           <PropertyGroup>
             <NuGetTargetMoniker Condition="'$(NuGetTargetMoniker)' == ''">native,Version=v11.0</NuGetTargetMoniker>
             <_NuGetTargetFallbackMoniker>native,Version=v0.0</_NuGetTargetFallbackMoniker>
-            <TargetFrameworks Condition="'$(TargetFrameworks)' == ''">native11.0</TargetFrameworks>
+            <TargetFramework Condition="'$(TargetFramework)' == ''">native11.0</TargetFramework>
           </PropertyGroup>
         </When>
         <When Condition="'$(PlatformToolsetVersion)' == '100'">
@@ -121,7 +121,7 @@ Copyright (c) .NET Foundation. All rights reserved.
           <PropertyGroup>
             <NuGetTargetMoniker Condition="'$(NuGetTargetMoniker)' == ''">native,Version=v10.0</NuGetTargetMoniker>
             <_NuGetTargetFallbackMoniker>native,Version=v0.0</_NuGetTargetFallbackMoniker>
-            <TargetFrameworks Condition="'$(TargetFrameworks)' == ''">native10.0</TargetFrameworks>
+            <TargetFramework Condition="'$(TargetFramework)' == ''">native10.0</TargetFramework>
           </PropertyGroup>
         </When>
         <When Condition="'$(PlatformToolsetVersion)' == '90'">
@@ -129,13 +129,13 @@ Copyright (c) .NET Foundation. All rights reserved.
           <PropertyGroup>
             <NuGetTargetMoniker Condition="'$(NuGetTargetMoniker)' == ''">native,Version=v9.0</NuGetTargetMoniker>
             <_NuGetTargetFallbackMoniker>native,Version=v0.0</_NuGetTargetFallbackMoniker>
-            <TargetFrameworks Condition="'$(TargetFrameworks)' == ''">native9.0</TargetFrameworks>
+            <TargetFramework Condition="'$(TargetFramework)' == ''">native9.0</TargetFramework>
           </PropertyGroup>
         </When>
         <Otherwise>
           <PropertyGroup>
             <NuGetTargetMoniker Condition="'$(NuGetTargetMoniker)' == ''">native,Version=v0.0</NuGetTargetMoniker>
-            <TargetFrameworks Condition="'$(TargetFrameworks)' == ''">native0.0</TargetFrameworks>
+            <TargetFramework Condition="'$(TargetFramework)' == ''">native0.0</TargetFramework>
           </PropertyGroup>
         </Otherwise>
       </Choose>

--- a/src/Microsoft.NuGet.Build.Tasks/Microsoft.NuGet.targets
+++ b/src/Microsoft.NuGet.Build.Tasks/Microsoft.NuGet.targets
@@ -69,78 +69,33 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <!--
   C++ has different toolsets, such as v140 (VS2015), v141 (VS2017), v142 (VS2019)
-  Earlier versions of the toolset are not compatible with each other, and VS2015 and later can be upward compatible.
+  
+  VS2017 toosets: 14.10.25017, 14.11.25503, 14.12.25827, 14.13.26128 ...
+  VS2019 toosets: 14.20.27508, 14.21.27702, 14.22.27905, 14.23.28105 ...
   -->
-  <Choose>
-    <When Condition="'$(Language)' == 'C++'">
-      <Choose>
-        <When Condition="'$(PlatformToolsetVersion)' == '142'">
-          <!--VS2019-->
-          <PropertyGroup>
-            <NuGetTargetMoniker Condition="'$(NuGetTargetMoniker)' == ''">native,Version=v14.2</NuGetTargetMoniker>
-            <!--Compatible 2017 2015-->
-            <_NuGetTargetFallbackMoniker>native,Version=v14.1;native,Version=v14.0;native,Version=v0.0</_NuGetTargetFallbackMoniker>
-            <TargetFramework Condition="'$(TargetFramework)' == ''">native14.2</TargetFramework>
-          </PropertyGroup>
-        </When>
-        <When Condition="'$(PlatformToolsetVersion)' == '141'">
-          <!--VS2017-->
-          <PropertyGroup>
-            <NuGetTargetMoniker Condition="'$(NuGetTargetMoniker)' == ''">native,Version=v14.1</NuGetTargetMoniker>
-            <!--Compatible 2015-->
-            <_NuGetTargetFallbackMoniker>native,Version=v14.0;native,Version=v0.0</_NuGetTargetFallbackMoniker>
-            <TargetFramework Condition="'$(TargetFramework)' == ''">native14.1</TargetFramework>
-          </PropertyGroup>
-        </When>
-        <When Condition="'$(PlatformToolsetVersion)' == '140'">
-          <!--VS2015-->
-          <PropertyGroup>
-            <NuGetTargetMoniker Condition="'$(NuGetTargetMoniker)' == ''">native,Version=v14.0</NuGetTargetMoniker>
-            <_NuGetTargetFallbackMoniker>native,Version=v0.0</_NuGetTargetFallbackMoniker>
-            <TargetFramework Condition="'$(TargetFramework)' == ''">native14.0</TargetFramework>
-          </PropertyGroup>
-        </When>
-        <When Condition="'$(PlatformToolsetVersion)' == '120'">
-          <!--VS2013-->
-          <PropertyGroup>
-            <NuGetTargetMoniker Condition="'$(NuGetTargetMoniker)' == ''">native,Version=v12.0</NuGetTargetMoniker>
-            <_NuGetTargetFallbackMoniker>native,Version=v0.0</_NuGetTargetFallbackMoniker>
-            <TargetFramework Condition="'$(TargetFramework)' == ''">native12.0</TargetFramework>
-          </PropertyGroup>
-        </When>
-        <When Condition="'$(PlatformToolsetVersion)' == '110'">
-          <!--VS2012-->
-          <PropertyGroup>
-            <NuGetTargetMoniker Condition="'$(NuGetTargetMoniker)' == ''">native,Version=v11.0</NuGetTargetMoniker>
-            <_NuGetTargetFallbackMoniker>native,Version=v0.0</_NuGetTargetFallbackMoniker>
-            <TargetFramework Condition="'$(TargetFramework)' == ''">native11.0</TargetFramework>
-          </PropertyGroup>
-        </When>
-        <When Condition="'$(PlatformToolsetVersion)' == '100'">
-          <!--VS2010-->
-          <PropertyGroup>
-            <NuGetTargetMoniker Condition="'$(NuGetTargetMoniker)' == ''">native,Version=v10.0</NuGetTargetMoniker>
-            <_NuGetTargetFallbackMoniker>native,Version=v0.0</_NuGetTargetFallbackMoniker>
-            <TargetFramework Condition="'$(TargetFramework)' == ''">native10.0</TargetFramework>
-          </PropertyGroup>
-        </When>
-        <When Condition="'$(PlatformToolsetVersion)' == '90'">
-          <!--VS2008-->
-          <PropertyGroup>
-            <NuGetTargetMoniker Condition="'$(NuGetTargetMoniker)' == ''">native,Version=v9.0</NuGetTargetMoniker>
-            <_NuGetTargetFallbackMoniker>native,Version=v0.0</_NuGetTargetFallbackMoniker>
-            <TargetFramework Condition="'$(TargetFramework)' == ''">native9.0</TargetFramework>
-          </PropertyGroup>
-        </When>
-        <Otherwise>
-          <PropertyGroup>
-            <NuGetTargetMoniker Condition="'$(NuGetTargetMoniker)' == ''">native,Version=v0.0</NuGetTargetMoniker>
-            <TargetFramework Condition="'$(TargetFramework)' == ''">native0.0</TargetFramework>
-          </PropertyGroup>
-        </Otherwise>
-      </Choose>
-    </When>
-  </Choose>
+  <PropertyGroup Condition="'$(Language)' == 'C++'">
+    <!--
+    VS2017 VS2019 support VCToolsVersion, like:
+    14.16.27023 (2017)
+    14.20.27508 (2019)
+    14.24.28314 (2019)
+    -->
+    <NuGetVCToolsVersion>$(VCToolsVersion)</NuGetVCToolsVersion>
+
+    <!--
+    others using PlatformToolsetVersion
+       
+    if PlatformToolsetVersion = 140, then NuGetVCToolsVersion = 14.0
+    if PlatformToolsetVersion = 141, then NuGetVCToolsVersion = 14.10
+    
+    -->
+    <NuGetVCToolsVersion Condition="'$(NuGetVCToolsVersion)' == '' and '$(PlatformToolsetVersion)' != '' and '$([MSBuild]::Modulo($(PlatformToolsetVersion), 10))' == '0'">$([MSBuild]::Divide($(PlatformToolsetVersion),10).ToString('f1'))</NuGetVCToolsVersion>
+    <NuGetVCToolsVersion Condition="'$(NuGetVCToolsVersion)' == '' and '$(PlatformToolsetVersion)' != ''">$([MSBuild]::Divide($(PlatformToolsetVersion),10).ToString('f2'))</NuGetVCToolsVersion>
+
+
+    <NuGetTargetMoniker Condition="'$(NuGetTargetMoniker)' == ''">native,Version=v$([MSBuild]::ValueOrDefault('$(NuGetVCToolsVersion)', '0.0'))</NuGetTargetMoniker>
+    <TargetFramework Condition="'$(TargetFramework)' == ''">native$(NuGetVCToolsVersion)</TargetFramework>
+  </PropertyGroup>
   
   <PropertyGroup>
     <ResolveNuGetPackages Condition="'$(ResolveNuGetPackages)' == '' and '$(MSBuildProjectExtension)' != '.xproj'">true</ResolveNuGetPackages>

--- a/src/Microsoft.NuGet.Build.Tasks/Microsoft.NuGet.targets
+++ b/src/Microsoft.NuGet.Build.Tasks/Microsoft.NuGet.targets
@@ -67,6 +67,81 @@ Copyright (c) .NET Foundation. All rights reserved.
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
   </PropertyGroup>
 
+  <!--
+  C++ has different toolsets, such as v140 (VS2015), v141 (VS2017), v142 (VS2019)
+  Earlier versions of the toolset are not compatible with each other, and VS2015 and later can be upward compatible.
+  -->
+  <Choose>
+    <When Condition="'$(Language)' == 'C++'">
+      <Choose>
+        <When Condition="'$(PlatformToolsetVersion)' == '142'">
+          <!--VS2019-->
+          <PropertyGroup>
+            <NuGetTargetMoniker Condition="'$(NuGetTargetMoniker)' == ''">native,Version=v14.2</NuGetTargetMoniker>
+            <!--Compatible 2017 2015-->
+            <_NuGetTargetFallbackMoniker>native,Version=v14.1;native,Version=v14.0;native,Version=v0.0</_NuGetTargetFallbackMoniker>
+            <TargetFrameworks Condition="'$(TargetFrameworks)' == ''">native14.2</TargetFrameworks>
+          </PropertyGroup>
+        </When>
+        <When Condition="'$(PlatformToolsetVersion)' == '141'">
+          <!--VS2017-->
+          <PropertyGroup>
+            <NuGetTargetMoniker Condition="'$(NuGetTargetMoniker)' == ''">native,Version=v14.1</NuGetTargetMoniker>
+            <!--Compatible 2015-->
+            <_NuGetTargetFallbackMoniker>native,Version=v14.0;native,Version=v0.0</_NuGetTargetFallbackMoniker>
+            <TargetFrameworks Condition="'$(TargetFrameworks)' == ''">native14.1</TargetFrameworks>
+          </PropertyGroup>
+        </When>
+        <When Condition="'$(PlatformToolsetVersion)' == '140'">
+          <!--VS2015-->
+          <PropertyGroup>
+            <NuGetTargetMoniker Condition="'$(NuGetTargetMoniker)' == ''">native,Version=v14.0</NuGetTargetMoniker>
+            <_NuGetTargetFallbackMoniker>native,Version=v0.0</_NuGetTargetFallbackMoniker>
+            <TargetFrameworks Condition="'$(TargetFrameworks)' == ''">native14.0</TargetFrameworks>
+          </PropertyGroup>
+        </When>
+        <When Condition="'$(PlatformToolsetVersion)' == '120'">
+          <!--VS2013-->
+          <PropertyGroup>
+            <NuGetTargetMoniker Condition="'$(NuGetTargetMoniker)' == ''">native,Version=v12.0</NuGetTargetMoniker>
+            <_NuGetTargetFallbackMoniker>native,Version=v0.0</_NuGetTargetFallbackMoniker>
+            <TargetFrameworks Condition="'$(TargetFrameworks)' == ''">native12.0</TargetFrameworks>
+          </PropertyGroup>
+        </When>
+        <When Condition="'$(PlatformToolsetVersion)' == '110'">
+          <!--VS2012-->
+          <PropertyGroup>
+            <NuGetTargetMoniker Condition="'$(NuGetTargetMoniker)' == ''">native,Version=v11.0</NuGetTargetMoniker>
+            <_NuGetTargetFallbackMoniker>native,Version=v0.0</_NuGetTargetFallbackMoniker>
+            <TargetFrameworks Condition="'$(TargetFrameworks)' == ''">native11.0</TargetFrameworks>
+          </PropertyGroup>
+        </When>
+        <When Condition="'$(PlatformToolsetVersion)' == '100'">
+          <!--VS2010-->
+          <PropertyGroup>
+            <NuGetTargetMoniker Condition="'$(NuGetTargetMoniker)' == ''">native,Version=v10.0</NuGetTargetMoniker>
+            <_NuGetTargetFallbackMoniker>native,Version=v0.0</_NuGetTargetFallbackMoniker>
+            <TargetFrameworks Condition="'$(TargetFrameworks)' == ''">native10.0</TargetFrameworks>
+          </PropertyGroup>
+        </When>
+        <When Condition="'$(PlatformToolsetVersion)' == '90'">
+          <!--VS2008-->
+          <PropertyGroup>
+            <NuGetTargetMoniker Condition="'$(NuGetTargetMoniker)' == ''">native,Version=v9.0</NuGetTargetMoniker>
+            <_NuGetTargetFallbackMoniker>native,Version=v0.0</_NuGetTargetFallbackMoniker>
+            <TargetFrameworks Condition="'$(TargetFrameworks)' == ''">native9.0</TargetFrameworks>
+          </PropertyGroup>
+        </When>
+        <Otherwise>
+          <PropertyGroup>
+            <NuGetTargetMoniker Condition="'$(NuGetTargetMoniker)' == ''">native,Version=v0.0</NuGetTargetMoniker>
+            <TargetFrameworks Condition="'$(TargetFrameworks)' == ''">native0.0</TargetFrameworks>
+          </PropertyGroup>
+        </Otherwise>
+      </Choose>
+    </When>
+  </Choose>
+  
   <PropertyGroup>
     <ResolveNuGetPackages Condition="'$(ResolveNuGetPackages)' == '' and '$(MSBuildProjectExtension)' != '.xproj'">true</ResolveNuGetPackages>
 
@@ -79,7 +154,6 @@ Copyright (c) .NET Foundation. All rights reserved.
     <BaseNuGetRuntimeIdentifier Condition="'$(BaseNuGetRuntimeIdentifier)' == '' and '$(TargetPlatformIdentifier)' == 'UAP'">win10</BaseNuGetRuntimeIdentifier>
     <BaseNuGetRuntimeIdentifier Condition="'$(BaseNuGetRuntimeIdentifier)' == ''">win</BaseNuGetRuntimeIdentifier>
 
-    <NuGetTargetMoniker Condition="'$(NuGetTargetMoniker)' == '' AND '$(Language)' == 'C++'">native,Version=v0.0</NuGetTargetMoniker>
     <UseTargetPlatformAsNuGetTargetMoniker Condition="'$(UseTargetPlatformAsNuGetTargetMoniker)' == '' AND '$(TargetFrameworkMoniker)' == '.NETCore,Version=v5.0'">true</UseTargetPlatformAsNuGetTargetMoniker>
     <NuGetTargetMoniker Condition="'$(NuGetTargetMoniker)' == '' AND '$(UseTargetPlatformAsNuGetTargetMoniker)' == 'true'">$(TargetPlatformIdentifier),Version=v$([System.Version]::Parse('$(TargetPlatformMinVersion)').ToString(3))</NuGetTargetMoniker>
     <NuGetTargetMoniker Condition="'$(NuGetTargetMoniker)' == '' AND '$(UseTargetPlatformAsNuGetTargetMoniker)' != 'true'">$(TargetFrameworkMoniker)</NuGetTargetMoniker>

--- a/src/Microsoft.NuGet.Build.Tasks/Microsoft.NuGet.targets
+++ b/src/Microsoft.NuGet.Build.Tasks/Microsoft.NuGet.targets
@@ -79,6 +79,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <BaseNuGetRuntimeIdentifier Condition="'$(BaseNuGetRuntimeIdentifier)' == '' and '$(TargetPlatformIdentifier)' == 'UAP'">win10</BaseNuGetRuntimeIdentifier>
     <BaseNuGetRuntimeIdentifier Condition="'$(BaseNuGetRuntimeIdentifier)' == ''">win</BaseNuGetRuntimeIdentifier>
 
+    <NuGetTargetMoniker Condition="'$(NuGetTargetMoniker)' == '' AND '$(Language)' == 'C++'">native,Version=v0.0</NuGetTargetMoniker>
     <UseTargetPlatformAsNuGetTargetMoniker Condition="'$(UseTargetPlatformAsNuGetTargetMoniker)' == '' AND '$(TargetFrameworkMoniker)' == '.NETCore,Version=v5.0'">true</UseTargetPlatformAsNuGetTargetMoniker>
     <NuGetTargetMoniker Condition="'$(NuGetTargetMoniker)' == '' AND '$(UseTargetPlatformAsNuGetTargetMoniker)' == 'true'">$(TargetPlatformIdentifier),Version=v$([System.Version]::Parse('$(TargetPlatformMinVersion)').ToString(3))</NuGetTargetMoniker>
     <NuGetTargetMoniker Condition="'$(NuGetTargetMoniker)' == '' AND '$(UseTargetPlatformAsNuGetTargetMoniker)' != 'true'">$(TargetFrameworkMoniker)</NuGetTargetMoniker>
@@ -98,7 +99,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <!-- If RuntimeIdentifiers weren't already specified for non-UAP projects, then generate it -->
   <PropertyGroup Condition="'$(BaseNuGetRuntimeIdentifier)' == 'win' and '$(NuGetRuntimeIdentifier)' != '' and '$(RuntimeIdentifiers)' == '' and '$(RuntimeIdentifier)' == ''">
-    <RuntimeIdentifiers>win;win-x86;win-x64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win;win-x86;win-x64;win-arm;win-arm64</RuntimeIdentifiers>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.NuGet.Build.Tasks/ResolveNuGetPackageAssets.cs
+++ b/src/Microsoft.NuGet.Build.Tasks/ResolveNuGetPackageAssets.cs
@@ -585,6 +585,7 @@ namespace Microsoft.NuGet.Build.Tasks
             {
                 case "C#": return "cs";
                 case "F#": return "fs";
+                case "C++": return "cpp";
                 default: return projectLanguage.ToLowerInvariant();
             }
         }


### PR DESCRIPTION
## Home issue
https://github.com/NuGet/Home/issues/8874

As we all know, packages.xml easily leads to wasted space and a large number of IO copy operations. So I hope that nuget can support VC++ to support PackageReference style.

## New features
1. add C++ Project PackageReference style restore support.
2. add C++ ARM/ARM64 Desktop application support.
3. add C++ Project TargetFramework support.
