### PR TITLE
Default to MSBuildProjectExtensionsPath when looking for a default assets file 

### DIFF
--- a/src/Microsoft.NuGet.Build.Tasks/Microsoft.NuGet.targets
+++ b/src/Microsoft.NuGet.Build.Tasks/Microsoft.NuGet.targets
@@ -32,7 +32,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <When Condition="'$(RestoreProjectStyle)' == 'PackageReference'">
       <!-- The RestoreProjectStyle property has been specified to PackageReference, so use that. -->
       <PropertyGroup>
-        <ProjectLockFile>$(BaseIntermediateOutputPath)project.assets.json</ProjectLockFile>
+        <ProjectLockFile>$(MSBuildProjectExtensionsPath)project.assets.json</ProjectLockFile>
       </PropertyGroup>
     </When>
 
@@ -57,7 +57,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <Otherwise>
       <!-- No assets or lock file provided at all, so fallback to project.assets.json file.-->
       <PropertyGroup>
-        <ProjectLockFile>$(BaseIntermediateOutputPath)project.assets.json</ProjectLockFile>
+        <ProjectLockFile>$(MSBuildProjectExtensionsPath)project.assets.json</ProjectLockFile>
       </PropertyGroup>
     </Otherwise>
   </Choose>


### PR DESCRIPTION
Fixes: https://github.com/dotnet/NuGet.BuildTasks/issues/82

See: See: NuGet/NuGet.Client#2131 and microsoft/msbuild#1603 for context.

Basically BaseIntermediateOutputPath is not ideal because that's not what current NuGet uses. 
MSBuild imports the generate nuget.g.props/targets based on MSBUildProjectExtensionsPath and that's NuGet writes. 

This affects customers such as: https://developercommunity.visualstudio.com/content/problem/970381/compiling-does-not-find-nuget-packages-that-were-j.html

I'd be happy to add a test if I can get pointers to it. 