### PR TITLE
Add aliases support for legacy package reference projects

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -6,5 +6,6 @@
     <add key="roslyn-tools" value="https://dotnet.myget.org/F/roslyn-tools/api/v3/index.json" />
     <add key="dotnet-core" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+    <add key="dotnet-eng" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" />
   </packageSources>
 </configuration>

--- a/src/Microsoft.NuGet.Build.Tasks.Tests/Json/WithTargets.assets.json
+++ b/src/Microsoft.NuGet.Build.Tasks.Tests/Json/WithTargets.assets.json
@@ -8,7 +8,9 @@
           "System": "4.5.0"
         },
         "compile": {
-          "ref/net45/System.Text.dll": {}
+          "ref/net45/System.Text.dll": {
+            "aliases" :  "Core"
+          }
         }
       }
     }

--- a/src/Microsoft.NuGet.Build.Tasks.Tests/Microsoft.NuGet.Build.Tasks.Tests.csproj
+++ b/src/Microsoft.NuGet.Build.Tasks.Tests/Microsoft.NuGet.Build.Tasks.Tests.csproj
@@ -4,6 +4,22 @@
   </PropertyGroup>
 
   <ItemGroup>
-	<ProjectReference Include="..\Microsoft.NuGet.Build.Tasks\Microsoft.NuGet.Build.Tasks.csproj"/>
+	<ProjectReference Include="..\Microsoft.NuGet.Build.Tasks\Microsoft.NuGet.Build.Tasks.csproj" />
   </ItemGroup>
+  
+  <ItemGroup>
+    <Compile Update="Json\Json.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>Json.resx</DependentUpon>
+    </Compile>
+  </ItemGroup>
+  
+  <ItemGroup>
+    <EmbeddedResource Update="Json\Json.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>Json.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+  </ItemGroup>
+  
 </Project>

--- a/src/Microsoft.NuGet.Build.Tasks.Tests/ReferenceResolutionTests.cs
+++ b/src/Microsoft.NuGet.Build.Tasks.Tests/ReferenceResolutionTests.cs
@@ -544,5 +544,25 @@ namespace Microsoft.NuGet.Build.Tasks.Tests
 
             Assert.DoesNotContain("ClassLibrary1", result.ReferencedPackages.Select(t => t.ItemSpec));
         }
+
+        [Fact]
+        public static void TestReferenceResolutionWithAliases()
+        {
+            using (var tempRoot = new TempRoot())
+            using (var disposableFile = new DisposableFile(tempRoot.CreateFile(extension: "assets.json").Path))
+            {
+                var result = NuGetTestHelpers.ResolvePackagesWithJsonFileContents(
+                        Encoding.UTF8.GetString(Json.Json.WithTargets_assets, 0, Json.Json.WithTargets_assets.Length),
+                        targetMoniker: ".NETFramework,Version=v4.5",
+                        runtimeIdentifier: "",
+                        allowFallbackOnTargetSelection: true,
+                        isLockFileProjectJsonBased: false);
+
+                // We should still have references. Since we have no runtime ID, we should have no copy local items
+                AssertHelpers.AssertCountOf(1, result.References);
+                Assert.Equal("Core", result.References.Single().GetMetadata("Aliases"));
+            }
+        }
+
     }
 }

--- a/src/Microsoft.NuGet.Build.Tasks/ResolveNuGetPackageAssets.cs
+++ b/src/Microsoft.NuGet.Build.Tasks/ResolveNuGetPackageAssets.cs
@@ -24,6 +24,7 @@ namespace Microsoft.NuGet.Build.Tasks
         internal const string NuGetIsFrameworkReference = "NuGetIsFrameworkReference";
         internal const string NuGetSourceType = "NuGetSourceType";
         internal const string NuGetSourceType_Package = "Package";
+        internal const string Aliases = "Aliases";
 
         internal const string ReferenceImplementationMetadata = "Implementation";
         internal const string ReferenceImageRuntimeMetadata = "ImageRuntime";
@@ -830,6 +831,11 @@ namespace Microsoft.NuGet.Build.Tasks
                 item.SetMetadata(NuGetIsFrameworkReference, "false");
                 item.SetMetadata(NuGetSourceType, NuGetSourceType_Package);
 
+                string aliases = file.Value["aliases"]?.ToString();
+                if (aliases != null)
+                {
+                    item.SetMetadata(Aliases, aliases);
+                }
                 items.Add(item);
 
                 // If there's a PDB alongside the implementation, we should copy that as well


### PR DESCRIPTION
Fixes https://github.com/dotnet/NuGet.BuildTasks/issues/70. 

Design at: https://github.com/NuGet/Home/blob/dev/designs/PackageReference-Extern-Alias.md

Specifically the details about the change here: https://github.com/NuGet/Home/blob/dev/designs/PackageReference-Extern-Alias.md#solution---technical-details