### PR TITLE
Make ProjectLockFile relative

### DIFF
--- a/src/Microsoft.NuGet.Build.Tasks/Microsoft.NuGet.targets
+++ b/src/Microsoft.NuGet.Build.Tasks/Microsoft.NuGet.targets
@@ -62,6 +62,18 @@ Copyright (c) .NET Foundation. All rights reserved.
     </Otherwise>
   </Choose>
 
+  <!--
+  The project system would prefer this to be a path relative to the project. Consider what
+  happens when the user creates a new project from a template: the project is first created
+  in a temporary location, and then moved to the final location. If the project system asks
+  for the property between those two steps and we give it an absolute path it will end up
+  watching the wrong location for updates to the lock file. However, if we give it a path
+  relative to the project file then that will still be correct after the move.
+  -->
+  <PropertyGroup>
+    <ProjectLockFile>$([MSBuild]::MakeRelative($(MSBuildProjectDirectory), $(ProjectLockFile)))</ProjectLockFile>
+  </PropertyGroup>
+  
   <!-- Add to MSBuildAllProjects in order to better support incremental builds. -->
   <PropertyGroup>
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>


### PR DESCRIPTION
Fixes [VS bug 1163000](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1163000).

The project system monitors the project.assets.json file for changes, which usually occur due to a NuGet restore. When it changes we need to run a design-time build to acquire the updated set of references and pass them along to the language service. We also use these references to figure out what packages to show under the References node.

Consider what happens when the user creates a new project: the project is first created (from a template) in a temporary location and then moved to the final location. If the project systems asks for the location of the project.assets.json (captured in the `ProjectLockFile` property) file in between these two steps and we give it an absolute path then it will end up watching the wrong location for updates to the lock file. If the user then adds a `PackageReference` to the project (e.g. via the NuGet package management UI) we won't know to run the design-time build, won't pick up the new references, and won't pass them along to the language service.

The fix here is to make `ProjectLockFile` a path relative to the project file if we can. This relative path will still be valid after the move, and the project system already has logic to convert it to a full path when it needs to set up the file watcher.