### PR TITLE
Go back to 2017 pool to establish baseline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ artifacts/
 project.lock.json
 *.nuget.props
 *.nuget.targets
+.tools

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -3,7 +3,7 @@ resources:
   clean: true
 
 queue:
-  name: VSEng-MicroBuildVS2019
+  name: VSEng-MicroBuildVS2017
   demands: Cmd
   timeoutInMinutes: 90
 


### PR DESCRIPTION
When moving to 2019 we get the following build error:

C:\Program Files\dotnet\sdk\5.0.100-rc.2.20479.15\Sdks\NuGet.Build.Tasks.Pack\build\NuGet.Build.Tasks.Pack.targets(207,5): error NU5128: Some target frameworks declared in the dependencies group of the
 nuspec and the lib/ref folder do not have exact matches in the other location. Consult the list of actions below: [G:\NuGet.BuildTasks\src\Microsoft.NuGet.Build.Tasks\Microsoft.NuGet.Build.Tasks.cspro
j]
C:\Program Files\dotnet\sdk\5.0.100-rc.2.20479.15\Sdks\NuGet.Build.Tasks.Pack\build\NuGet.Build.Tasks.Pack.targets(207,5): error NU5128: - Add lib or ref assemblies for the net46 target framework [G:\N
uGet.BuildTasks\src\Microsoft.NuGet.Build.Tasks\Microsoft.NuGet.Build.Tasks.csproj]
##vso[task.logissue type=error;sourcepath=C:\Program Files\dotnet\sdk\5.0.100-rc.2.20479.15\Sdks\NuGet.Build.Tasks.Pack\build\NuGet.Build.Tasks.Pack.targets;linenumber=207;columnnumber=5;code=NU5128;]Some target frameworks declared in the dependencies group of the nuspec and the lib/ref folder do not have exact matches in the other location. Consult the list of actions below:%0D%0A- Add lib or ref assemblies for the net46 target framework

Tracked by #91 