### PR TITLE
Revert "Changing pool on official build due to excessive wait times"

### DIFF
--- a/build/official.yml
+++ b/build/official.yml
@@ -5,7 +5,7 @@ resources:
   clean: true
 
 queue:
-  name: VSEngSS-MicroBuild2017
+  name: VSEng-MicroBuildVS2017
   demands: Cmd
   timeoutInMinutes: 90
 


### PR DESCRIPTION
There's an outage so all pools are broken. Reverting to our original one as it generally tends to be extremely quick