### PR TITLE
Revert "Use Scale Set pools for Build Pipelines"

### DIFF
--- a/build/official.yml
+++ b/build/official.yml
@@ -5,7 +5,7 @@ resources:
   clean: true
 
 queue:
-  name: VSEngSS-MicroBuild2017
+  name: VSEng-MicroBuildVS2017
   demands: Cmd
   timeoutInMinutes: 90
 


### PR DESCRIPTION
Reverts dotnet/NuGet.BuildTasks#115