### PR TITLE
Update to 2019 1ES pool

### DIFF
--- a/build/official.yml
+++ b/build/official.yml
@@ -20,7 +20,7 @@ jobs:
       LclPackageId: 'LCL-JUNO-PROD-NBUILDTASKS'
 - job: Build
   pool:
-    name: VSEngSS-MicroBuild2017
+    name: VSEng-MicroBuild2019-1ES
     demands: Cmd
     timeoutInMinutes: 90
   steps:


### PR DESCRIPTION
The 2017 pool has been deprecated. Updated the official (signed) build to the 2019 1ES pool. Additional information here: https://devdiv.visualstudio.com/DevDiv/_wiki/wikis/DevDiv.wiki/12566/Using-Scale-Set-pools-for-Build-Pipelines