### PR TITLE
Update to 2019 1ES pool (fix)

### DIFF
--- a/build/official.yml
+++ b/build/official.yml
@@ -20,7 +20,7 @@ jobs:
       LclPackageId: 'LCL-JUNO-PROD-NBUILDTASKS'
 - job: Build
   pool:
-    name: VSEng-MicroBuild2019-1ES
+    name: VSEngSS-MicroBuild2019-1ES
     demands: Cmd
     timeoutInMinutes: 90
   steps:


### PR DESCRIPTION
Follow-up to: https://github.com/dotnet/NuGet.BuildTasks/pull/135

Forgot the SS (scale set) as part of the pool name.