### PR TITLE
PublishTestResults version update

### DIFF
--- a/build/official.yml
+++ b/build/official.yml
@@ -64,10 +64,10 @@ jobs:
     continueOnError: true
     condition: not(succeeded())
 
-  - task: PublishTestResults@1
+  - task: PublishTestResults@2
     displayName: Publish Test Results
     inputs:
-      testRunner: XUnit
+      testResultsFormat: XUnit
       testResultsFiles: 'artifacts/TestResults/$(BuildConfiguration)/*.xml'
       mergeTestResults: true
       testRunTitle: 'Unit Tests'


### PR DESCRIPTION
Updates the version of the PublishTestResults task to remove the build warning.

![image](https://user-images.githubusercontent.com/17788297/158033027-1eed54d7-f586-48c6-977a-1748394d8711.png)
