### PR TITLE
Add SBOM to the official build pipeline

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,9 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
   <Import Project="Sdk.targets" Sdk="Microsoft.DotNet.Arcade.Sdk" />
-
-  <!-- Updates insertion manifests (json) for creating the vsman files for insertion to include the SPDX SBOM json. -->
-  <Target Name="UpdateManifestJsonForSbom" AfterTargets="SwixBuild">
-    <Exec ContinueOnError="false" Command="powershell -NonInteractive -NoLogo -NoProfile -ExecutionPolicy Unrestricted -Command &quot;. $(MSBuildThisFileDirectory)build\UpdateManifestJsonForSbom.ps1 -manifestJsonPath '$(VisualStudioSetupInsertionPath)$(ManifestJsonName).json' -sbomMetadataPath '$(ArtifactsBinDir)spdx_2.2\manifest.spdx.json'&quot;" />
-  </Target>
 </Project>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,4 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
   <Import Project="Sdk.targets" Sdk="Microsoft.DotNet.Arcade.Sdk" />
+
+  <!-- Updates insertion manifests (json) for creating the vsman files for insertion to include the SPDX SBOM json. -->
+  <Target Name="UpdateManifestJsonForSbom" AfterTargets="SwixBuild">
+    <Exec ContinueOnError="false" Command="powershell -NonInteractive -NoLogo -NoProfile -ExecutionPolicy Unrestricted -Command &quot;. $(MSBuildThisFileDirectory)build\UpdateManifestJsonForSbom.ps1 -manifestJsonPath '$(VisualStudioSetupInsertionPath)$(ManifestJsonName).json' -sbomMetadataPath '$(ArtifactsBinDir)spdx_2.2\manifest.spdx.json'&quot;" />
+  </Target>
 </Project>

--- a/build/UpdateManifestJsonForSbom.ps1
+++ b/build/UpdateManifestJsonForSbom.ps1
@@ -1,0 +1,29 @@
+# Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+# This updates the provided manifest JSON with the SBOM metadata file. The manifest JSON is used to create the .vsman file for VS insertions.
+
+param ([Parameter(Mandatory=$true)] [String] $manifestJsonPath, [Parameter(Mandatory=$true)] [String] $sbomMetadataPath)
+
+$ErrorActionPreference = 'Stop'
+
+Write-Host 'Inputs:'
+Write-Host "manifestJsonPath: $manifestJsonPath"
+Write-Host "sbomMetadataPath: $sbomMetadataPath"
+
+$manifestJson = Get-Content $manifestJsonPath | ConvertFrom-Json
+$vsixPackageName = [IO.Path]::GetFileNameWithoutExtension($manifestJson.packages[0].payloads[0].fileName)
+$newSbomFileName = "$($vsixPackageName)_sbom.json"
+# https://stackoverflow.com/a/48601321/294804
+$sbomPackageObject = [PSCustomObject]@{
+  'fileName' = $newSbomFileName
+  'size' = (Get-Item $sbomMetadataPath).Length
+}
+$manifestJson.packages[0].payloads += $sbomPackageObject
+$manifestJson | ConvertTo-Json -Depth 5 | Set-Content $manifestJsonPath
+
+$destinationDir = [IO.Path]::GetDirectoryName($manifestJsonPath)
+$newSbomMetadataPath = "$destinationDir\$newSbomFileName"
+Copy-Item -Path $sbomMetadataPath -Destination $newSbomMetadataPath
+
+Write-Host 'Saved Output:'
+Write-Host "newSbomMetadataPath: $newSbomMetadataPath"

--- a/build/official.yml
+++ b/build/official.yml
@@ -33,7 +33,7 @@ jobs:
       esrpSigning: true
     condition: and(succeeded(), ne(variables['SignType'], ''))
 
-  - task: ms-vseng.MicroBuildTasks.32f78468-e895-4f47-962c-58a699361df8.MicroBuildSwixPlugin@1
+  - task: MicroBuildSwixPlugin@4
     displayName: Install Swix Plugin
 
   - script: eng\common\CIBuild.cmd 

--- a/build/official.yml
+++ b/build/official.yml
@@ -36,22 +36,31 @@ jobs:
   - task: MicroBuildSwixPlugin@4
     displayName: Install Swix Plugin
 
-  - script: eng\common\CIBuild.cmd 
-            -configuration $(BuildConfiguration)
-            /p:OfficialBuildId=$(Build.BuildNumber)
-            /p:VisualStudioDropName=$(VisualStudioDropName)
-            /p:DotNetSignType=$(SignType)
-            /p:PublishToSymbolServer=true
-            /p:DotNetSymbolServerTokenMsdl=$(microsoft-symbol-server-pat)
-            /p:DotNetSymbolServerTokenSymWeb=$(symweb-symbol-server-pat)
-            /v:normal
+  - task: PowerShell@2
     displayName: Build (for SBOM)
+    inputs:
+      filePath: eng\common\build.ps1
+      arguments: '-configuration $(BuildConfiguration) -restore -build'
+      failOnStderr: true
+
+  # - script: eng\common\CIBuild.cmd 
+  #           -configuration $(BuildConfiguration)
+  #           /p:OfficialBuildId=$(Build.BuildNumber)
+  #           /p:VisualStudioDropName=$(VisualStudioDropName)
+  #           /p:DotNetSignType=$(SignType)
+  #           /p:PublishToSymbolServer=true
+  #           /p:DotNetSymbolServerTokenMsdl=$(microsoft-symbol-server-pat)
+  #           /p:DotNetSymbolServerTokenSymWeb=$(symweb-symbol-server-pat)
+  #           /v:normal
+  #   displayName: Build (for SBOM)
 
   - template: ..\eng\common\templates\steps\generate-sbom.yml
 
+  # - script: eng\common\CIBuild.cmd -clean
+  #   displayName: Clean SBOM build artifacts
+
   - script: eng\common\CIBuild.cmd 
             -configuration $(BuildConfiguration)
-            -clean
             /p:OfficialBuildId=$(Build.BuildNumber)
             /p:VisualStudioDropName=$(VisualStudioDropName)
             /p:DotNetSignType=$(SignType)

--- a/build/official.yml
+++ b/build/official.yml
@@ -44,6 +44,7 @@ jobs:
             /p:PublishToSymbolServer=true
             /p:DotNetSymbolServerTokenMsdl=$(microsoft-symbol-server-pat)
             /p:DotNetSymbolServerTokenSymWeb=$(symweb-symbol-server-pat)
+            /v:normal
     displayName: Build
 
   - template: ..\eng\common\templates\steps\generate-sbom.yml

--- a/build/official.yml
+++ b/build/official.yml
@@ -45,9 +45,23 @@ jobs:
             /p:DotNetSymbolServerTokenMsdl=$(microsoft-symbol-server-pat)
             /p:DotNetSymbolServerTokenSymWeb=$(symweb-symbol-server-pat)
             /v:normal
-    displayName: Build
+    displayName: Build (for SBOM)
 
   - template: ..\eng\common\templates\steps\generate-sbom.yml
+
+  - script: eng\common\CIBuild.cmd 
+            -configuration $(BuildConfiguration)
+            -clean
+            /p:OfficialBuildId=$(Build.BuildNumber)
+            /p:VisualStudioDropName=$(VisualStudioDropName)
+            /p:DotNetSignType=$(SignType)
+            /p:PublishToSymbolServer=true
+            /p:DotNetSymbolServerTokenMsdl=$(microsoft-symbol-server-pat)
+            /p:DotNetSymbolServerTokenSymWeb=$(symweb-symbol-server-pat)
+            /p:SbomManifestJsonDirectory=$(Build.SourcesDirectory)\artifacts\VSSetup\$(BuildConfiguration)
+            /p:SbomMetadataDirectory=$(Build.ArtifactStagingDirectory)\sbom
+            /v:normal
+    displayName: Build
 
   # Publishes setup VSIXes to a drop.
   # Note: The insertion tool looks for the display name of this task in the logs.

--- a/build/official.yml
+++ b/build/official.yml
@@ -67,7 +67,7 @@ jobs:
             /p:PublishToSymbolServer=true
             /p:DotNetSymbolServerTokenMsdl=$(microsoft-symbol-server-pat)
             /p:DotNetSymbolServerTokenSymWeb=$(symweb-symbol-server-pat)
-            /p:SbomManifestJsonDirectory=$(Build.SourcesDirectory)\artifacts\VSSetup\$(BuildConfiguration)
+            /p:SbomManifestJsonDirectory=$(Build.SourcesDirectory)\artifacts\VSSetup\$(BuildConfiguration)\Insertion
             /p:SbomMetadataDirectory=$(Build.ArtifactStagingDirectory)\sbom
             /v:normal
     displayName: Build

--- a/build/official.yml
+++ b/build/official.yml
@@ -46,6 +46,8 @@ jobs:
             /p:DotNetSymbolServerTokenSymWeb=$(symweb-symbol-server-pat)
     displayName: Build
 
+  - template: ..\eng\common\templates\steps\generate-sbom.yml
+
   # Publishes setup VSIXes to a drop.
   # Note: The insertion tool looks for the display name of this task in the logs.
   - task: ms-vseng.MicroBuildTasks.4305a8de-ba66-4d8b-b2d1-0dc4ecbbf5e8.MicroBuildUploadVstsDropFolder@1

--- a/build/official.yml
+++ b/build/official.yml
@@ -36,6 +36,7 @@ jobs:
   - task: MicroBuildSwixPlugin@4
     displayName: Install Swix Plugin
 
+  # Quick build to produce DLLs for SBOM generation only.
   - task: PowerShell@2
     displayName: Build (for SBOM)
     inputs:
@@ -43,21 +44,7 @@ jobs:
       arguments: '-configuration $(BuildConfiguration) -restore -build'
       failOnStderr: true
 
-  # - script: eng\common\CIBuild.cmd 
-  #           -configuration $(BuildConfiguration)
-  #           /p:OfficialBuildId=$(Build.BuildNumber)
-  #           /p:VisualStudioDropName=$(VisualStudioDropName)
-  #           /p:DotNetSignType=$(SignType)
-  #           /p:PublishToSymbolServer=true
-  #           /p:DotNetSymbolServerTokenMsdl=$(microsoft-symbol-server-pat)
-  #           /p:DotNetSymbolServerTokenSymWeb=$(symweb-symbol-server-pat)
-  #           /v:normal
-  #   displayName: Build (for SBOM)
-
   - template: ..\eng\common\templates\steps\generate-sbom.yml
-
-  # - script: eng\common\CIBuild.cmd -clean
-  #   displayName: Clean SBOM build artifacts
 
   - script: eng\common\CIBuild.cmd 
             -configuration $(BuildConfiguration)

--- a/setup/Swix/Microsoft.NuGet.Build.Tasks.Setup/Microsoft.NuGet.Build.Tasks.Setup.csproj
+++ b/setup/Swix/Microsoft.NuGet.Build.Tasks.Setup/Microsoft.NuGet.Build.Tasks.Setup.csproj
@@ -1,24 +1,24 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">	
-  <PropertyGroup>	
-    <TargetFramework>net461</TargetFramework>	
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net461</TargetFramework>
     <VisualStudioInsertionComponent>Microsoft.NuGet.Build.Tasks</VisualStudioInsertionComponent>
-  </PropertyGroup>	
+  </PropertyGroup>
 
-  <ItemGroup>	
-    <ProjectReference Include="..\..\..\src\Microsoft.NuGet.Build.Tasks\Microsoft.NuGet.Build.Tasks.csproj" />	
-  </ItemGroup>	
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\Microsoft.NuGet.Build.Tasks\Microsoft.NuGet.Build.Tasks.csproj" />
+  </ItemGroup>
 
-  <ItemGroup>	
-    <SwrProperty Include="MSBuildProjectDirectory=$(MSBuildProjectDirectory)" />	
-    <SwrProperty Include="VsixVersion=$(VsixVersion)" />	
-    <SwrProperty Include="ArtifactsBinDir=$(ArtifactsBinDir)" />	
+  <ItemGroup>
+    <SwrProperty Include="MSBuildProjectDirectory=$(MSBuildProjectDirectory)" />
+    <SwrProperty Include="VsixVersion=$(VsixVersion)" />
+    <SwrProperty Include="ArtifactsBinDir=$(ArtifactsBinDir)" />
     <SwrProperty Include="Configuration=$(Configuration)" />
     <SwrProperty Include="MajorVersion=$(MajorVersion)" />
-  </ItemGroup>	
+  </ItemGroup>
 
+  <ItemGroup>
+    <SwrFile Include="files.swr" />
+  </ItemGroup>
 
-  <ItemGroup>	
-    <SwrFile Include="files.swr" />	
-  </ItemGroup>	
-
-</Project> 
+</Project>

--- a/setup/Swix/Microsoft.NuGet.Build.Tasks.Setup/Microsoft.NuGet.Build.Tasks.Setup.csproj
+++ b/setup/Swix/Microsoft.NuGet.Build.Tasks.Setup/Microsoft.NuGet.Build.Tasks.Setup.csproj
@@ -21,4 +21,9 @@
     <SwrFile Include="files.swr" />
   </ItemGroup>
 
+  <!-- Updates insertion manifests (json) for creating the vsman files for insertion to include the SPDX SBOM json. -->
+  <Target Name="UpdateManifestJsonForSbom" AfterTargets="SwixBuild" Condition="'$(SbomManifestJsonDirectory)' != '' AND '$(SbomMetadataDirectory)' != ''">
+    <Exec ContinueOnError="false" Command="powershell -NonInteractive -NoLogo -NoProfile -ExecutionPolicy Unrestricted -Command &quot;. $(MSBuildThisFileDirectory)..\..\..\build\UpdateManifestJsonForSbom.ps1 -manifestJsonPath '$(SbomManifestJsonDirectory)\Microsoft.NuGet.Build.Tasks.Setup.json' -sbomMetadataPath '$(SbomMetadataDirectory)\spdx_2.2\manifest.spdx.json'&quot;" />
+  </Target>
+
 </Project>


### PR DESCRIPTION
Detailed information here: https://github.com/dotnet/project-system/pull/7955

This adds software bill of materials (SBOM) to the official build pipeline. This is required for Microsoft products and the information is required to be in our `.vsman` file for Visual Studio insertion. I reused the same `.ps1` script I made for the project-system repo to do the update process for the json manifest.

Successful build: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=5948260&view=results

From the manifest json:
```json
"payloads": [
    {
        "fileName": "Microsoft.NuGet.Build.Tasks.Setup.vsix",
        "size": ------
    },
    {
        "fileName": "Microsoft.NuGet.Build.Tasks.Setup_sbom.json",
        "size": ------
    }
],
```

From the vsman file:

![image](https://user-images.githubusercontent.com/17788297/160509683-32a4678d-8356-4030-9e82-b249349479a9.png)