### PR TITLE
Fix symbol check for insertion

### DIFF
--- a/build/official.yml
+++ b/build/official.yml
@@ -46,6 +46,9 @@ jobs:
 
   - template: ..\eng\common\templates\steps\generate-sbom.yml
 
+  - script: eng\common\CIBuild.cmd -clean
+    displayName: Clean
+
   - script: eng\common\CIBuild.cmd 
             -configuration $(BuildConfiguration)
             /p:OfficialBuildId=$(Build.BuildNumber)


### PR DESCRIPTION
The symbol check was failing for insertions after my previous change to add SBOM. I had a hunch that it was because I wasn't cleaning the artifacts after I do the quick build to generate SBOM. This seems to have worked as now symbol check has passed.

Successful draft insertion: https://devdiv.visualstudio.com/DevDiv/_git/VS/pullrequest/389567