### PR TITLE
Fix vcxproj global package restore

### DIFF
--- a/src/Microsoft.NuGet.Build.Tasks.Tests/Json/GlobalMSBuildPlugin.vcxproj.json
+++ b/src/Microsoft.NuGet.Build.Tasks.Tests/Json/GlobalMSBuildPlugin.vcxproj.json
@@ -1,0 +1,88 @@
+{
+  "version": 3,
+  "targets": {
+    "native,Version=v0.0": {
+      "Custom.MSBuildPlugin/1.0.0": {
+        "type": "package",
+        "build": {
+          "buildTransitive/Custom.MSBuildPlugin.targets": {}
+        },
+        "buildMultiTargeting": {
+          "buildMultitargeting/Custom.MSBuildPlugin.targets": {}
+        }
+      }
+    }
+  },
+  "libraries": {
+    "Custom.MSBuildPlugin/1.0.0": {
+      "sha512": "YrfgJpLLhkaTNf2pbg1fKk6W5hTts3RejwxWEnj0NQ/ZADzLO5u25wxIA5yPk1PaK/Lw0OL0jOdcJuTQ0Evo4A==",
+      "type": "package",
+      "path": "custom.msbuildplugin/1.0.0",
+      "files": [
+        ".nupkg.metadata",
+        "custom.msbuildplugin.1.0.0.nupkg.sha512",
+        "custom.msbuildplugin.nuspec",
+        "build/Custom.MSBuildPlugin.targets",
+        "buildMultitargeting/Custom.MSBuildPlugin.targets",
+        "buildTransitive/Custom.MSBuildPlugin.targets"
+      ]
+    }
+  },
+  "projectFileDependencyGroups": {
+    "native,Version=v0.0": [
+      "Custom.MSBuildPlugin >= 1.0.0",
+    ]
+  },
+  "packageFolders": {
+    "C:\\Users\\Default\\.nuget\\packages\\": {}
+  },
+  "project": {
+    "version": "1.0.0",
+    "restore": {
+      "projectUniqueName": "C:\\src\\Example.vcxproj",
+      "projectName": "Example",
+      "projectPath": "C:\\src\\Example.vcxproj",
+      "packagesPath": "C:\\Users\\Default\\.nuget\\packages\\",
+      "outputPath": "C:\\src\\obj\\",
+      "projectStyle": "PackageReference",
+      "centralPackageVersionsManagementEnabled": true,
+      "configFilePaths": [
+        "C:\\src\\NuGet.Config",
+        "C:\\Users\\Default\\AppData\\Roaming\\NuGet\\NuGet.Config",
+        "C:\\Program Files (x86)\\NuGet\\Config\\Microsoft.VisualStudio.Offline.config"
+      ],
+      "originalTargetFrameworks": [
+        "net7.0"
+      ],
+      "sources": {
+        "https://nuget.org": {}
+      },
+      "frameworks": {
+        "native": {
+          "targetAlias": "net7.0",
+          "projectReferences": {}
+        }
+      },
+      "warningProperties": {
+        "allWarningsAsErrors": true
+      }
+    },
+    "frameworks": {
+      "native": {
+        "targetAlias": "net7.0",
+        "dependencies": {
+          "Custom.MSBuildPlugin": {
+            "include": "Runtime, Build, Native, ContentFiles, Analyzers",
+            "suppressParent": "All",
+            "target": "Package",
+            "version": "[1.0.0, )",
+            "versionCentrallyManaged": true
+          },
+        },
+        "centralPackageVersions": {
+          "Custom.MSBuildPlugin": "[1.0.0, )",
+        }
+      }
+    }
+  }
+}

--- a/src/Microsoft.NuGet.Build.Tasks.Tests/Json/Json.Designer.cs
+++ b/src/Microsoft.NuGet.Build.Tasks.Tests/Json/Json.Designer.cs
@@ -19,7 +19,7 @@ namespace Microsoft.NuGet.Build.Tasks.Tests.Json {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Json {
@@ -376,6 +376,15 @@ namespace Microsoft.NuGet.Build.Tasks.Tests.Json {
             get {
                 object obj = ResourceManager.GetObject("WithTargets_assets", resourceCulture);
                 return ((byte[])(obj));
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string.
+        /// </summary>
+        internal static string GlobalMSBuildPlugin_vcxproj {
+            get {
+                return ResourceManager.GetString("GlobalMSBuildPlugin_vcxproj", resourceCulture);
             }
         }
     }

--- a/src/Microsoft.NuGet.Build.Tasks.Tests/Json/Json.resx
+++ b/src/Microsoft.NuGet.Build.Tasks.Tests/Json/Json.resx
@@ -157,4 +157,7 @@
   <data name="WithTargets_assets" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>WithTargets.assets.json;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
+  <data name="GlobalMSBuildPlugin_vcxproj" type="System.Resources.ResXFileRef, System.Windows.Forms">
+	  <value>GlobalMSBuildPlugin.vcxproj.json;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
+  </data>
 </root>

--- a/src/Microsoft.NuGet.Build.Tasks.Tests/Json/Json.resx
+++ b/src/Microsoft.NuGet.Build.Tasks.Tests/Json/Json.resx
@@ -158,6 +158,6 @@
     <value>WithTargets.assets.json;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="GlobalMSBuildPlugin_vcxproj" type="System.Resources.ResXFileRef, System.Windows.Forms">
-	  <value>GlobalMSBuildPlugin.vcxproj.json;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
+    <value>GlobalMSBuildPlugin.vcxproj.json;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
   </data>
 </root>

--- a/src/Microsoft.NuGet.Build.Tasks.Tests/NuGetTestHelpers.cs
+++ b/src/Microsoft.NuGet.Build.Tasks.Tests/NuGetTestHelpers.cs
@@ -79,7 +79,14 @@ namespace Microsoft.NuGet.Build.Tasks.Tests
                 task.RuntimeIdentifier = runtimeIdentifier;
                 task.ProjectLockFile = projectLockJsonFile.Path;
                 task.ProjectLanguage = projectLanguage;
-                task.TargetMonikers = new ITaskItem[] { new TaskItem(targetMoniker) };
+                if (targetMoniker != null)
+                {
+                    task.TargetMonikers = new ITaskItem[] { new TaskItem(targetMoniker) };
+                }
+                else
+                {
+                    task.TargetMonikers = Array.Empty<ITaskItem>();
+                }
 
                 // When we create the task for unit-testing purposes, the constructor sets an internal bit which should always
                 // cause task.Execute to throw.

--- a/src/Microsoft.NuGet.Build.Tasks.Tests/ResolveNuGetPackageAssetsTests.cs
+++ b/src/Microsoft.NuGet.Build.Tasks.Tests/ResolveNuGetPackageAssetsTests.cs
@@ -1,0 +1,640 @@
+// Copyright (c) .NET Foundation. All rights reserved. 
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information. 
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Microsoft.Build.Utilities;
+using Microsoft.NuGet.Build.Tasks.Tests.Helpers;
+using Xunit;
+
+namespace Microsoft.NuGet.Build.Tasks.Tests
+{
+    public sealed class ResolveNuGetPackageAssetsTests
+    {
+        [Fact(Skip = "Disabling for CI")]
+        public static void TestReferenceResolutionWithRuntimeIDWin10X86()
+        {
+            var result = NuGetTestHelpers.ResolvePackagesWithJsonFileContents(
+                Json.Json.Win10,
+                targetMoniker: ".NETCore,Version=v5.0",
+                runtimeIdentifier: "win10-x86");
+
+            AssertHelpers.AssertCountOf(101, result.References);
+            AssertHelpers.AssertCountOf(119, result.CopyLocalItems);
+            AssertHelpers.AssertNoTargetPaths(result.CopyLocalItems);
+        }
+
+        [Fact(Skip = "Disabling for CI")]
+        public static void TestReferenceResolutionWithRuntimeIDWin10X64()
+        {
+            var result = NuGetTestHelpers.ResolvePackagesWithJsonFileContents(
+                Json.Json.Win10,
+                targetMoniker: ".NETCore,Version=v5.0",
+                runtimeIdentifier: "win10-x64");
+
+            AssertHelpers.AssertCountOf(101, result.References);
+            AssertHelpers.AssertCountOf(119, result.CopyLocalItems);
+            AssertHelpers.AssertNoTargetPaths(result.CopyLocalItems);
+        }
+
+        [Fact(Skip = "Disabling for CI")]
+        public static void TestReferenceResolutionWithRuntimeIDWin10X86Aot()
+        {
+            var result = NuGetTestHelpers.ResolvePackagesWithJsonFileContents(
+                Json.Json.Win10,
+                targetMoniker: ".NETCore,Version=v5.0",
+                runtimeIdentifier: "win10-x86-aot");
+
+            AssertHelpers.AssertCountOf(101, result.References);
+            AssertHelpers.AssertCountOf(141, result.CopyLocalItems);
+            AssertHelpers.AssertNoTargetPaths(result.CopyLocalItems);
+        }
+
+        [Fact(Skip = "Disabling for CI")]
+        public static void TestReferenceResolutionWithRuntimeIDWin10X64Aot()
+        {
+            var result = NuGetTestHelpers.ResolvePackagesWithJsonFileContents(
+                Json.Json.Win10,
+                targetMoniker: ".NETCore,Version=v5.0",
+                runtimeIdentifier: "win10-x64-aot");
+
+            AssertHelpers.AssertCountOf(101, result.References);
+            AssertHelpers.AssertCountOf(141, result.CopyLocalItems);
+            AssertHelpers.AssertNoTargetPaths(result.CopyLocalItems);
+        }
+
+        [Fact(Skip = "Disabling for CI")]
+        public static void TestReferenceResolutionWithMissingRuntimeIDAndFallback()
+        {
+            var result = NuGetTestHelpers.ResolvePackagesWithJsonFileContents(
+                Json.Json.Win10,
+                targetMoniker: ".NETCore,Version=v5.0",
+                runtimeIdentifier: "missing-runtime-identifier",
+                allowFallbackOnTargetSelection: true);
+
+            // We should still have references. We'll assert that CopyLocalItems contains something, but it's purely best
+            // effort and so there's no promise that it'll ever contain any specific items
+            AssertHelpers.AssertCountOf(101, result.References);
+            Assert.NotEmpty(result.CopyLocalItems);
+        }
+
+        [Fact(Skip = "Disabling for CI")]
+        public static void TestReferenceResolutionWithMissingRuntimeIDAndNoFallback()
+        {
+            var exception = Assert.Throws<ExceptionFromResource>(() =>
+                NuGetTestHelpers.ResolvePackagesWithJsonFileContents(
+                    Json.Json.Win10,
+                    targetMoniker: ".NETCore,Version=v5.0",
+                    runtimeIdentifier: "missing-runtime-identifier",
+                    allowFallbackOnTargetSelection: false));
+
+            Assert.Equal(nameof(Strings.MissingRuntimeInProjectJson), exception.ResourceName);
+            Assert.Equal(new[] { "missing-runtime-identifier", "\"missing-runtime-identifier\": { }" }, exception.MessageArgs);
+        }
+
+        [Fact(Skip = "Disabling for CI")]
+        public static void TestReferenceResolutionWithMissingRuntimeIDAndNoFallbackAndNoRuntimesSection()
+        {
+            var exception = Assert.Throws<ExceptionFromResource>(() =>
+                NuGetTestHelpers.ResolvePackagesWithJsonFileContents(
+                    Json.Json.Win10,
+                    targetMoniker: ".NETCore,Version=v5.0",
+                    runtimeIdentifier: "missing-runtime-identifier",
+                    allowFallbackOnTargetSelection: false,
+                    projectJsonFileContents: "{ }"));
+
+            Assert.Equal(nameof(Strings.MissingRuntimesSectionInProjectJson), exception.ResourceName);
+            Assert.Equal(new[] { "\"runtimes\": { \"missing-runtime-identifier\": { } }" }, exception.MessageArgs);
+        }
+
+        [Fact(Skip = "Disabling for CI")]
+        public static void TestReferenceResolutionWithMissingRuntimeIDAndNoFallbackInProjectCsproj()
+        {
+            using (var tempRoot = new TempRoot())
+            using (var disposableFile = new DisposableFile(tempRoot.CreateFile(extension: "assets.json").Path))
+            {
+                var exception = Assert.Throws<ExceptionFromResource>(() =>
+                NuGetTestHelpers.ResolvePackagesWithJsonFileContents(
+                    Encoding.UTF8.GetString(Json.Json.WithTargets_assets, 0, Json.Json.WithTargets_assets.Length),
+                    targetMoniker: ".NETFramework,Version=v4.5",
+                    runtimeIdentifier: "missing-runtime-identifier",
+                    allowFallbackOnTargetSelection: false,
+                    isLockFileProjectJsonBased: false));
+
+                Assert.Equal(nameof(Strings.MissingRuntimeIdentifierInProjectFile), exception.ResourceName);
+                Assert.Equal(new[] { "missing-runtime-identifier", "missing-runtime-identifier" }, exception.MessageArgs);
+            }
+        }
+
+        [Fact(Skip = "Disabling for CI")]
+        public static void TestReferenceResolutionWithMissingRuntimeIDAndNoFallbackAndNoRuntimesSectionInProjectCsproj()
+        {
+            var exception = Assert.Throws<ExceptionFromResource>(() =>
+                NuGetTestHelpers.ResolvePackagesWithJsonFileContents(
+                    Json.Json.Win10,
+                    targetMoniker: ".NETCore,Version=v5.0",
+                    runtimeIdentifier: "missing-runtime-identifier",
+                    allowFallbackOnTargetSelection: false,
+                    projectJsonFileContents: "{ }"));
+
+            Assert.Equal(nameof(Strings.MissingRuntimesSectionInProjectJson), exception.ResourceName);
+            Assert.Equal(new[] { "\"runtimes\": { \"missing-runtime-identifier\": { } }" }, exception.MessageArgs);
+        }
+
+        [Fact(Skip = "Disabling for CI")]
+        public static void TestReferenceResolutionWithMissingTargetFrameworkAndNoFallback()
+        {
+            var exception = Assert.Throws<ExceptionFromResource>(() =>
+                NuGetTestHelpers.ResolvePackagesWithJsonFileContents(
+                    Json.Json.Win10,
+                    targetMoniker: "Missing,Version=1.0",
+                    runtimeIdentifier: "missing-runtime-identifier",
+                    allowFallbackOnTargetSelection: false));
+
+            Assert.Equal(nameof(Strings.MissingFrameworkInProjectJson), exception.ResourceName);
+            Assert.Equal(new[] { "Missing,Version=1.0" }, exception.MessageArgs);
+        }
+
+        [Fact(Skip = "Disabling for CI")]
+        public static void TestReferenceResolutionWithMissingTargetFrameworkAndNoFallbackInProjectCsproj()
+        {
+            using (var tempRoot = new TempRoot())
+            using (var disposableFile = new DisposableFile(tempRoot.CreateFile(extension: "assets.json").Path))
+            {
+                var exception = Assert.Throws<ExceptionFromResource>(() =>
+                    NuGetTestHelpers.ResolvePackagesWithJsonFileContents(
+                        Encoding.UTF8.GetString(Json.Json.WithoutTargets_assets, 0, Json.Json.WithoutTargets_assets.Length),
+                        targetMoniker: "Missing,Version=1.0",
+                        runtimeIdentifier: "missing-runtime-identifier",
+                        allowFallbackOnTargetSelection: false,
+                        isLockFileProjectJsonBased: false));
+
+                Assert.Equal(nameof(Strings.MissingFrameworkInProjectFile), exception.ResourceName);
+                Assert.Equal(new[] { "Missing,Version=1.0" }, exception.MessageArgs);
+            }
+        }
+
+        [Fact(Skip = "Disabling for CI")]
+        public static void TestReferenceResolutionWithMissingTargetFrameworkAndFallback()
+        {
+            var result = NuGetTestHelpers.ResolvePackagesWithJsonFileContents(
+                Json.Json.Win10,
+                targetMoniker: "MissingFrameworkMoniker,Version=v42.0",
+                runtimeIdentifier: "",
+                allowFallbackOnTargetSelection: true);
+
+            // We should still have references. Since we have no runtime ID, we should have no copy local items
+            AssertHelpers.AssertCountOf(101, result.References);
+            AssertHelpers.AssertCountOf(0, result.CopyLocalItems);
+        }
+
+        [Fact(Skip = "Disabling for CI")]
+        public static void TestReferenceResolutionWithMissingTargetFrameworkAndFallbackInProjectCsproj()
+        {
+            using (var tempRoot = new TempRoot())
+            using (var disposableFile = new DisposableFile(tempRoot.CreateFile(extension: "assets.json").Path))
+            {
+                var result = NuGetTestHelpers.ResolvePackagesWithJsonFileContents(
+                        Encoding.UTF8.GetString(Json.Json.WithTargets_assets, 0, Json.Json.WithTargets_assets.Length),
+                        targetMoniker: "MissingFrameworkMoniker,Version=v42.0",
+                        runtimeIdentifier: "",
+                        allowFallbackOnTargetSelection: true,
+                        isLockFileProjectJsonBased: false);
+
+                // We should still have references. Since we have no runtime ID, we should have no copy local items
+                AssertHelpers.AssertCountOf(1, result.References);
+                AssertHelpers.AssertCountOf(0, result.CopyLocalItems);
+            }
+        }
+
+        [Theory(Skip = "Disabling for CI")]
+        [InlineData(true, nameof(Strings.NoTargetsInLockFileForProjectJson))]
+        [InlineData(false, nameof(Strings.NoTargetsInLockFileForProjectFile))]
+        public static void TestReferenceResolutionWithMissingTargets(bool isProjectJsonBased, string errorResourceName)
+        {
+            using (var tempRoot = new TempRoot())
+            using (var disposableFile = new DisposableFile(tempRoot.CreateFile(extension: "assets.json").Path))
+            {
+                var exception = Assert.Throws<ExceptionFromResource>(() =>
+                    NuGetTestHelpers.ResolvePackagesWithJsonFileContents(
+                            Encoding.UTF8.GetString(Json.Json.WithoutTargets_assets, 0, Json.Json.WithoutTargets_assets.Length),
+                            targetMoniker: "MissingFrameworkMoniker,Version=v42.0",
+                            runtimeIdentifier: "",
+                            allowFallbackOnTargetSelection: true,
+                            isLockFileProjectJsonBased: isProjectJsonBased));
+
+                Assert.Equal(errorResourceName, exception.ResourceName);
+            }
+        }
+
+        [Fact(Skip = "Disabling for CI")]
+        public static void TestReferenceResolutionWithNoRuntimeID()
+        {
+            var result = NuGetTestHelpers.ResolvePackagesWithJsonFileContents(
+                Json.Json.Win10,
+                targetMoniker: ".NETCore,Version=v5.0",
+                runtimeIdentifier: "");
+
+            // We should still have references, but no copy local
+            AssertHelpers.AssertCountOf(101, result.References);
+            AssertHelpers.AssertCountOf(0, result.CopyLocalItems);
+        }
+
+        [Fact(Skip = "Disabling for CI")]
+        public static void PackagesHaveMetadataWithPackageIdAndVersion()
+        {
+            var result = NuGetTestHelpers.ResolvePackagesWithJsonFileContents(
+                Json.Json.Win10,
+                targetMoniker: ".NETCore,Version=v5.0",
+                runtimeIdentifier: "win10-x86");
+
+            var immutableCopyLocalitem = result.CopyLocalItems.Single(i => i.ItemSpec.EndsWith("System.Collections.Immutable.dll"));
+
+            Assert.Equal("System.Collections.Immutable", immutableCopyLocalitem.GetMetadata(ResolveNuGetPackageAssets.NuGetPackageIdMetadata));
+            Assert.Equal("1.1.36", immutableCopyLocalitem.GetMetadata(ResolveNuGetPackageAssets.NuGetPackageVersionMetadata));
+        }
+
+
+        [Fact(Skip = "Disabling for CI")]
+        public static void ReferencedPackagesCorrectlyParsed()
+        {
+            var result = NuGetTestHelpers.ResolvePackagesWithJsonFileContents(
+                Json.Json.Win10,
+                targetMoniker: ".NETCore,Version=v5.0",
+                runtimeIdentifier: "");
+
+            // We should still have references, but no copy local
+            AssertHelpers.AssertCountOf(5, result.ReferencedPackages);
+
+            var packageNames = result.ReferencedPackages.Select(t => t.ItemSpec);
+
+            Assert.Contains("Microsoft.NETCore.UniversalWindowsPlatform", packageNames);
+        }
+
+        [Fact(Skip = "Disabling for CI")]
+        public static void ExcludingFrameworkReferencesActuallyExcludesFrameworkReferences()
+        {
+            var result = NuGetTestHelpers.ResolvePackagesWithJsonFileContents(
+                Json.Json.FluentAssertions,
+                targetMoniker: ".NETFramework,Version=v4.5.2",
+                runtimeIdentifier: "",
+                includeFrameworkReferences: false);
+
+            // We should only have references from the core package
+            AssertHelpers.AssertCountOf(2, result.References);
+            Assert.True(result.References.All(r => r.ItemSpec.Contains("FluentAssertions")));
+
+            // This should still count as the reference to a package
+            var packageNames = result.ReferencedPackages.Select(t => t.ItemSpec);
+            Assert.Contains("FluentAssertions", packageNames);
+        }
+
+        [Fact(Skip = "Disabling for CI")]
+        public static void IncludingFrameworkReferencesActuallyIncludesFrameworkReferences()
+        {
+            var result = NuGetTestHelpers.ResolvePackagesWithJsonFileContents(
+                Json.Json.FluentAssertions,
+                targetMoniker: ".NETFramework,Version=v4.5.2",
+                runtimeIdentifier: "",
+                includeFrameworkReferences: true);
+
+            // We should have references to the package itself plus framework packages
+            AssertHelpers.AssertCountOf(4, result.References);
+            Assert.True(result.References.All(r => r.ItemSpec.Contains("FluentAssertions") ||
+                                                   r.ItemSpec == "System.Xml" ||
+                                                   r.ItemSpec == "System.Xml.Linq"));
+
+            // This should still count as the reference to a package
+            var packageNames = result.ReferencedPackages.Select(t => t.ItemSpec);
+            Assert.Contains("FluentAssertions", packageNames);
+        }
+
+        [Fact(Skip = "Disabling for CI")]
+        public static void AllPackageReferencesAreMarkedAsSuch()
+        {
+            var result = NuGetTestHelpers.ResolvePackagesWithJsonFileContents(
+                Json.Json.FluentAssertions,
+                targetMoniker: ".NETFramework,Version=v4.5.2",
+                runtimeIdentifier: "",
+                includeFrameworkReferences: true);
+
+            // We should have references to the package itself plus framework packages
+            AssertHelpers.AssertCountOf(4, result.References);
+            Assert.All(result.References, r => Assert.Equal(ResolveNuGetPackageAssets.NuGetSourceType_Package, r.GetMetadata(ResolveNuGetPackageAssets.NuGetSourceType)));
+        }
+
+        [Fact(Skip = "Disabling for CI")]
+        public static void CopyLocalContentsIncludePdbsIfAvailable()
+        {
+            var result = NuGetTestHelpers.ResolvePackagesWithJsonFileContents(
+                Json.Json.FluentAssertionsAndWin10,
+                targetMoniker: "UAP,Version=v10.0",
+                runtimeIdentifier: "win10-x86",
+                includeFrameworkReferences: true);
+
+            Assert.Single(result.CopyLocalItems, r => r.ItemSpec.EndsWithPath("FluentAssertions.dll"));
+            Assert.Single(result.CopyLocalItems, r => r.ItemSpec.EndsWithPath("FluentAssertions.pdb"));
+            Assert.Single(result.CopyLocalItems, r => r.ItemSpec.EndsWithPath("FluentAssertions.Core.dll"));
+            Assert.Single(result.CopyLocalItems, r => r.ItemSpec.EndsWithPath("FluentAssertions.Core.pdb"));
+        }
+
+        [Fact(Skip = "Disabling for CI")]
+        public static void FrameworkReferencesAreNotProvidedIfAlreadyProvidedByAnotherPackage()
+        {
+            var result = NuGetTestHelpers.ResolvePackagesWithJsonFileContents(
+                Json.Json.FluentAssertionsAndWin10,
+                targetMoniker: "UAP,Version=v10.0",
+                runtimeIdentifier: "",
+                includeFrameworkReferences: true);
+
+            // There should be exactly one reference to System.Xml.dll, and no other references
+            Assert.Single(result.References.Where(r => r.ItemSpec.EndsWith("System.Xml.dll")));
+            Assert.Empty(result.References.Where(r => r.ItemSpec == "System.Xml"));
+        }
+
+        [Fact(Skip = "Disabling for CI")]
+        public static void AllNuGetReferencesHaveValidIsFrameworkReferenceProperty()
+        {
+            var result = NuGetTestHelpers.ResolvePackagesWithJsonFileContents(
+                Json.Json.FluentAssertions,
+                targetMoniker: ".NETFramework,Version=v4.5.2",
+                runtimeIdentifier: "");
+
+            var key = ResolveNuGetPackageAssets.NuGetIsFrameworkReference;
+            var values = result.References.Select(r => r.GetMetadata(key));
+
+            Assert.All(result.References, r => Assert.Contains(key, r.MetadataNames.Cast<string>()));
+            Assert.All(values, v => Assert.Contains(v, new[] { "true", "false" }));
+        }
+
+        [Fact(Skip = "Disabling for CI")]
+        public static void AllReferencesHaveCorrectIsFrameworkReferenceProperty()
+        {
+            var result = NuGetTestHelpers.ResolvePackagesWithJsonFileContents(
+                Json.Json.FluentAssertions,
+                targetMoniker: ".NETFramework,Version=v4.5.2",
+                runtimeIdentifier: "");
+
+            var references = result.References.ToDictionary(
+                r => r.ItemSpec,
+                r => r.GetMetadata(ResolveNuGetPackageAssets.NuGetIsFrameworkReference)
+            );
+
+            AssertHelpers.AssertCountOf(4, result.References);
+
+            var corePath = Path.Combine(result.ReferenceTemporaryPath, @"FluentAssertions\3.4.1\lib\net45\FluentAssertions.Core.dll");
+            Assert.True(references.ContainsKey(corePath));
+            Assert.Equal("false", references[corePath]);
+
+            var mainPath = Path.Combine(result.ReferenceTemporaryPath, @"FluentAssertions\3.4.1\lib\net45\FluentAssertions.dll");
+            Assert.True(references.ContainsKey(mainPath));
+            Assert.Equal("false", references[mainPath]);
+
+            Assert.Equal("true", references["System.Xml"]);
+            Assert.Equal("true", references["System.Xml.Linq"]);
+        }
+
+        [Fact(Skip = "Disabling for CI")]
+        public static void NativeWinMDSetsMetadata()
+        {
+            string imageRuntimeVersion = "WindowsRuntime 1.3";
+            TryGetRuntimeVersion tryGetRuntimeVersion = p => imageRuntimeVersion;
+            var result = NuGetTestHelpers.ResolvePackagesWithJsonFileContents(
+                Json.Json.nativeWinMD,
+                targetMoniker: ".NETCore,Version=v5.0",
+                runtimeIdentifier: "win10-x86",
+                tryGetRuntimeVersion: tryGetRuntimeVersion);
+
+            var winmd = result.CopyLocalItems.FirstOrDefault(c =>
+                Path.GetExtension(c.ItemSpec).Equals(".winmd", StringComparison.OrdinalIgnoreCase));
+
+            Assert.NotNull(winmd);
+            Assert.Equal(imageRuntimeVersion, winmd.GetMetadata("ImageRuntime"));
+            Assert.Equal("true", winmd.GetMetadata("WinMDFile"));
+            Assert.Equal("Native", winmd.GetMetadata("WinMDFileType"));
+            Assert.False(string.IsNullOrEmpty(winmd.GetMetadata("Implementation")), "implementation should be set for native winmd");
+            Assert.Equal(Path.GetFileNameWithoutExtension(winmd.ItemSpec) + ".dll", winmd.GetMetadata("Implementation"), StringComparer.OrdinalIgnoreCase);
+        }
+
+        [Fact(Skip = "Disabling for CI")]
+        public static void ManagedWinMDDoesNotSetsMetadata()
+        {
+            string imageRuntimeVersion = "WindowsRuntime 1.4;CLR v4.0.30319";
+            TryGetRuntimeVersion tryGetRuntimeVersion = p => imageRuntimeVersion;
+            var result = NuGetTestHelpers.ResolvePackagesWithJsonFileContents(
+                Json.Json.nativeWinMD,
+                targetMoniker: ".NETCore,Version=v5.0",
+                runtimeIdentifier: "win10-x86",
+                tryGetRuntimeVersion: tryGetRuntimeVersion);
+
+            var winmd = result.CopyLocalItems.FirstOrDefault(c =>
+                Path.GetExtension(c.ItemSpec).Equals(".winmd", StringComparison.OrdinalIgnoreCase));
+
+            Assert.NotNull(winmd);
+            Assert.Equal(imageRuntimeVersion, winmd.GetMetadata("ImageRuntime"));
+            Assert.Equal("true", winmd.GetMetadata("WinMDFile"));
+            Assert.Equal("Managed", winmd.GetMetadata("WinMDFileType"));
+            Assert.True(string.IsNullOrEmpty(winmd.GetMetadata("Implementation")), "implementation should not be set for managed winmd");
+        }
+
+        [Fact(Skip = "Disabling for CI")]
+        public static void BogusWinMDDoesNotSetImplementation()
+        {
+            string imageRuntimeVersion = "BogusRuntime 1.4;C1R v4.0.30319";
+            TryGetRuntimeVersion tryGetRuntimeVersion = p => imageRuntimeVersion;
+            var result = NuGetTestHelpers.ResolvePackagesWithJsonFileContents(
+                Json.Json.nativeWinMD,
+                targetMoniker: ".NETCore,Version=v5.0",
+                runtimeIdentifier: "win10-x86",
+                tryGetRuntimeVersion: tryGetRuntimeVersion);
+
+            var winmd = result.CopyLocalItems.FirstOrDefault(c =>
+                Path.GetExtension(c.ItemSpec).Equals(".winmd", StringComparison.OrdinalIgnoreCase));
+
+            Assert.NotNull(winmd);
+            Assert.Equal(imageRuntimeVersion, winmd.GetMetadata("ImageRuntime"));
+            Assert.True(string.IsNullOrEmpty(winmd.GetMetadata("WinMDFile")));
+            Assert.True(string.IsNullOrEmpty(winmd.GetMetadata("WinMDFileType")));
+            Assert.True(string.IsNullOrEmpty(winmd.GetMetadata("Implementation")), "implementation should not be set for bogus winmd");
+        }
+
+        [Fact(Skip = "Disabling for CI")]
+        public static void TestTargetPathCollisionsFound()
+        {
+            var result = NuGetTestHelpers.ResolvePackagesWithJsonFileContents(
+                Json.Json.Win10_Edm,
+                targetMoniker: ".NETCore,Version=v5.0",
+                runtimeIdentifier: "win10-x86");
+
+            AssertHelpers.AssertConsistentTargetPaths(result.CopyLocalItems);
+        }
+
+        [Fact(Skip = "Disabling for CI")]
+        public static void TestTargetPathCollisionsFound2()
+        {
+            var result = NuGetTestHelpers.ResolvePackagesWithJsonFileContents(
+                Json.Json.Win10_xunit,
+                targetMoniker: ".NETCore,Version=v5.0",
+                runtimeIdentifier: "win10-x86");
+
+            AssertHelpers.AssertConsistentTargetPaths(result.CopyLocalItems);
+        }
+
+        [Fact(Skip = "Disabling for CI")]
+        public static void MultipleProjectFileDependencyGroups()
+        {
+            var resultFor45 = NuGetTestHelpers.ResolvePackagesWithJsonFileContents(
+                Json.Json.MultipleProjectFileDependencyGroups,
+                targetMoniker: ".NETFramework,Version=v4.5",
+                runtimeIdentifier: "win",
+                allowFallbackOnTargetSelection: true);
+
+            var packageNames = resultFor45.ReferencedPackages.Select(t => t.ItemSpec);
+
+            Assert.Equal("Newtonsoft.Json", packageNames.Single());
+
+            var resultFor46 = NuGetTestHelpers.ResolvePackagesWithJsonFileContents(
+                Json.Json.MultipleProjectFileDependencyGroups,
+                targetMoniker: ".NETFramework,Version=v4.6",
+                runtimeIdentifier: "win",
+                allowFallbackOnTargetSelection: true);
+
+            AssertHelpers.AssertCountOf(1, resultFor46.ReferencedPackages);
+
+            packageNames = resultFor46.ReferencedPackages.Select(t => t.ItemSpec);
+
+            Assert.Contains("FluentAssertions", packageNames);
+        }
+
+        // Regression test for https://devdiv.visualstudio.com/DevDiv/_workitems?id=500532&_a=edit
+        [Fact(Skip = "Disabling for CI")]
+        public static void MultipleProjectFileDependencyGroups_MismatchedCases()
+        {
+            var resultFor45 = NuGetTestHelpers.ResolvePackagesWithJsonFileContents(
+                Json.Json.MultipleProjectFileDependencyGroups_CaseMismatch,
+                targetMoniker: ".NETFramework,Version=v4.5",
+                runtimeIdentifier: "win",
+                allowFallbackOnTargetSelection: true);
+
+            var packageNames = resultFor45.ReferencedPackages.Select(t => t.ItemSpec);
+
+            Assert.Equal("Newtonsoft.Json", packageNames.Single(), ignoreCase: true);
+
+            var resultFor46 = NuGetTestHelpers.ResolvePackagesWithJsonFileContents(
+                Json.Json.MultipleProjectFileDependencyGroups,
+                targetMoniker: ".NETFramework,Version=v4.6",
+                runtimeIdentifier: "win",
+                allowFallbackOnTargetSelection: true);
+
+            AssertHelpers.AssertCountOf(1, resultFor46.ReferencedPackages);
+
+            packageNames = resultFor46.ReferencedPackages.Select(t => t.ItemSpec);
+
+            Assert.Equal("FluentAssertions", packageNames.Single(), ignoreCase: true);
+        }
+
+        [Fact(Skip = "Disabling for CI")]
+        public static void ProjectsNotIncludedInReferences()
+        {
+            var result = NuGetTestHelpers.ResolvePackagesWithJsonFileContents(
+                Json.Json.ProjectDependency,
+                targetMoniker: ".NETFramework,Version=v4.5.2",
+                runtimeIdentifier: "win");
+
+            Assert.DoesNotContain("ClassLibrary1", result.ReferencedPackages.Select(t => t.ItemSpec));
+        }
+
+        [Fact]
+        public static void TestReferenceResolutionWithAliases()
+        {
+            using (var tempRoot = new TempRoot())
+            using (var disposableFile = new DisposableFile(tempRoot.CreateFile(extension: "assets.json").Path))
+            {
+                var result = NuGetTestHelpers.ResolvePackagesWithJsonFileContents(
+                        Encoding.UTF8.GetString(Json.Json.WithTargets_assets, 0, Json.Json.WithTargets_assets.Length),
+                        targetMoniker: ".NETFramework,Version=v4.5",
+                        runtimeIdentifier: "",
+                        allowFallbackOnTargetSelection: true,
+                        isLockFileProjectJsonBased: false);
+
+                // We should still have references. Since we have no runtime ID, we should have no copy local items
+                AssertHelpers.AssertCountOf(1, result.References);
+                Assert.Equal("Core", result.References.Single().GetMetadata("Aliases"));
+            }
+        }
+
+        [Fact]
+        public static void TestVcxprojWithCustomMSBuildPluginGlobalPackageReference_ExactTargetMoniker_AllowFallback()
+        {
+            // Ensure parsing does not fail.
+            ResolvePackagesResult result = NuGetTestHelpers.ResolvePackagesWithJsonFileContents(
+                Json.Json.GlobalMSBuildPlugin_vcxproj,
+                targetMoniker: ".NetCoreApp,Version=v7.0",
+                runtimeIdentifier: "",
+                allowFallbackOnTargetSelection: true,
+                isLockFileProjectJsonBased: false);
+            Assert.NotNull(result);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public static void TestVcxprojWithCustomMSBuildPluginGlobalPackageReference_ExactTargetMoniker_NoRid(bool allowFallbackOnTargetSelection)
+        {
+            // Ensure parsing does not fail.
+            ResolvePackagesResult result = NuGetTestHelpers.ResolvePackagesWithJsonFileContents(
+                Json.Json.GlobalMSBuildPlugin_vcxproj,
+                targetMoniker: ".NetCoreApp,Version=v7.0",
+                runtimeIdentifier: "",
+                allowFallbackOnTargetSelection: allowFallbackOnTargetSelection,
+                isLockFileProjectJsonBased: false);
+            Assert.NotNull(result);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public static void TestVcxprojWithCustomMSBuildPluginGlobalPackageReference_NoTargetMonikers_NoRid(bool allowFallbackOnTargetSelection)
+        {
+            // Ensure parsing does not fail.
+            ResolvePackagesResult result = NuGetTestHelpers.ResolvePackagesWithJsonFileContents(
+                Json.Json.GlobalMSBuildPlugin_vcxproj,
+                targetMoniker: null,  // Similar to how NuGet resolver runs vcxproj resolution.
+                runtimeIdentifier: "",
+                allowFallbackOnTargetSelection: allowFallbackOnTargetSelection,
+                isLockFileProjectJsonBased: false);
+            Assert.NotNull(result);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public static void TestVcxprojWithCustomMSBuildPluginGlobalPackageReference_NoTargetMonikers_WithRid(bool allowFallbackOnTargetSelection)
+        {
+            // With a non-null/empty RID, target resolution will require a RID (GetTargetOrAttemptFallback(..., true).
+            // Ensure parsing does not fail, it should fall back to the first target in the json targets list.
+            ResolvePackagesResult result = NuGetTestHelpers.ResolvePackagesWithJsonFileContents(
+                Json.Json.GlobalMSBuildPlugin_vcxproj,
+                targetMoniker: null,  // Similar to how NuGet resolver runs vcxproj resolution.
+                runtimeIdentifier: "native",
+                allowFallbackOnTargetSelection: allowFallbackOnTargetSelection,
+                isLockFileProjectJsonBased: false);
+            Assert.NotNull(result);
+        }
+
+        [Fact]
+        public static void TestVcxprojWithCustomMSBuildPluginGlobalPackageReference_IncorrectTargetMoniker_WithRid()
+        {
+            // With a non-null/empty RID, target resolution will require a RID (GetTargetOrAttemptFallback(..., true).
+            // The non-matching targetMoniker will trigger failure logic.
+            Assert.Throws<ExceptionFromResource>(() => NuGetTestHelpers.ResolvePackagesWithJsonFileContents(
+                Json.Json.GlobalMSBuildPlugin_vcxproj,
+                targetMoniker: ".NetCoreApp,Version=v7.0",
+                runtimeIdentifier: "not_native",
+                allowFallbackOnTargetSelection: false,
+                isLockFileProjectJsonBased: false));
+        }
+    }
+}

--- a/src/Microsoft.NuGet.Build.Tasks/ResolveNuGetPackageAssets.cs
+++ b/src/Microsoft.NuGet.Build.Tasks/ResolveNuGetPackageAssets.cs
@@ -779,7 +779,7 @@ namespace Microsoft.NuGet.Build.Tasks
                 nameof(Strings.MissingFrameworkInProjectJson) :
                 nameof(Strings.MissingFrameworkInProjectFile);
 
-            string itemSpec = TargetMonikers.FirstOrDefault()?.ItemSpec ?? "???";
+            string itemSpec = TargetMonikers.FirstOrDefault()?.ItemSpec ?? "No target moniker specified";
             ThrowExceptionIfNotAllowingFallback(missingFrameworkErrorString, itemSpec);
         }
 


### PR DESCRIPTION
Fix the case of .vcxproj file restore when there are no TargetMonikers and there may or may not be a RID. For #154 