### PR TITLE
Add win-arm64 to default RIDs

### DIFF
--- a/src/Microsoft.NuGet.Build.Tasks/Microsoft.NuGet.targets
+++ b/src/Microsoft.NuGet.Build.Tasks/Microsoft.NuGet.targets
@@ -110,7 +110,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <!-- If RuntimeIdentifiers weren't already specified for non-UAP projects, then generate it -->
   <PropertyGroup Condition="'$(BaseNuGetRuntimeIdentifier)' == 'win' and '$(NuGetRuntimeIdentifier)' != '' and '$(RuntimeIdentifiers)' == '' and '$(RuntimeIdentifier)' == ''">
-    <RuntimeIdentifiers>win;win-x86;win-x64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win;win-x86;win-x64;win-arm64</RuntimeIdentifiers>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
# Summary

As pointed out by @zivkan in [AB#1698505](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1698505), the default RID list is missing win-arm64, which manifests as a failure to restore packages when targeting Windows ARM64 in legacy (non-SDK style) projects.

# Fix

win-arm64 is a first-class supported platform so it is added to the default RID list, as suggested 

# Testing

Verified that the scenario of restoring an ARM64 .NET Framework app in Visual Studio works with this change.
