### PR TITLE
Clarify missing RID error

### DIFF
--- a/src/Microsoft.NuGet.Build.Tasks/Strings.resx
+++ b/src/Microsoft.NuGet.Build.Tasks/Strings.resx
@@ -147,7 +147,7 @@
     <comment>0 package id</comment>
   </data>
   <data name="MissingRuntimeIdentifierInProjectFile" xml:space="preserve">
-    <value>Your project file doesn't list '{0}' as a "RuntimeIdentifier". You should add '{1}' to the "RuntimeIdentifiers" property in your project file and then re-run NuGet restore. RuntimeIdentifiers should always be the complete list of RIDs supported by the project, regardless of the current configuration, platform or target. A single unconditioned RuntimeIdentifiers property is recommended.</value>
+    <value>Your project file doesn't list '{0}' as a "RuntimeIdentifier". You should add '{1}' to the "RuntimeIdentifiers" property in your project file and then re-run NuGet restore. RuntimeIdentifiers should always be the complete list of RIDs supported by the project, regardless of the current configuration, platform or target. A single RuntimeIdentifiers property with no condition is recommended.</value>
     <comment>0 &amp;1 - Runtime Identifier</comment>
   </data>
   <data name="MissingRuntimeIdentifierPropertyInProjectFile" xml:space="preserve">

--- a/src/Microsoft.NuGet.Build.Tasks/Strings.resx
+++ b/src/Microsoft.NuGet.Build.Tasks/Strings.resx
@@ -147,7 +147,7 @@
     <comment>0 package id</comment>
   </data>
   <data name="MissingRuntimeIdentifierInProjectFile" xml:space="preserve">
-    <value>Your project file doesn't list '{0}' as a "RuntimeIdentifier". You should add '{1}' to the "RuntimeIdentifiers" property in your project file and then re-run NuGet restore.</value>
+    <value>Your project file doesn't list '{0}' as a "RuntimeIdentifier". You should add '{1}' to the "RuntimeIdentifiers" property in your project file (RuntimeIdentifiers should always be the complete list of RIDs supported by the project, regardless of the current configuration, platform or target. Single unconditioned RuntimeIdentifiers property is recommended) and then re-run NuGet restore.</value>
     <comment>0 &amp;1 - Runtime Identifier</comment>
   </data>
   <data name="MissingRuntimeIdentifierPropertyInProjectFile" xml:space="preserve">

--- a/src/Microsoft.NuGet.Build.Tasks/Strings.resx
+++ b/src/Microsoft.NuGet.Build.Tasks/Strings.resx
@@ -147,7 +147,7 @@
     <comment>0 package id</comment>
   </data>
   <data name="MissingRuntimeIdentifierInProjectFile" xml:space="preserve">
-    <value>Your project file doesn't list '{0}' as a "RuntimeIdentifier". You should add '{1}' to the "RuntimeIdentifiers" property in your project file (RuntimeIdentifiers should always be the complete list of RIDs supported by the project, regardless of the current configuration, platform or target. Single unconditioned RuntimeIdentifiers property is recommended) and then re-run NuGet restore.</value>
+    <value>Your project file doesn't list '{0}' as a "RuntimeIdentifier". You should add '{1}' to the "RuntimeIdentifiers" property in your project file and then re-run NuGet restore. RuntimeIdentifiers should always be the complete list of RIDs supported by the project, regardless of the current configuration, platform or target. A single unconditioned RuntimeIdentifiers property is recommended</value>
     <comment>0 &amp;1 - Runtime Identifier</comment>
   </data>
   <data name="MissingRuntimeIdentifierPropertyInProjectFile" xml:space="preserve">

--- a/src/Microsoft.NuGet.Build.Tasks/Strings.resx
+++ b/src/Microsoft.NuGet.Build.Tasks/Strings.resx
@@ -147,7 +147,7 @@
     <comment>0 package id</comment>
   </data>
   <data name="MissingRuntimeIdentifierInProjectFile" xml:space="preserve">
-    <value>Your project file doesn't list '{0}' as a "RuntimeIdentifier". You should add '{1}' to the "RuntimeIdentifiers" property in your project file and then re-run NuGet restore. RuntimeIdentifiers should always be the complete list of RIDs supported by the project, regardless of the current configuration, platform or target. A single unconditioned RuntimeIdentifiers property is recommended</value>
+    <value>Your project file doesn't list '{0}' as a "RuntimeIdentifier". You should add '{1}' to the "RuntimeIdentifiers" property in your project file and then re-run NuGet restore. RuntimeIdentifiers should always be the complete list of RIDs supported by the project, regardless of the current configuration, platform or target. A single unconditioned RuntimeIdentifiers property is recommended.</value>
     <comment>0 &amp;1 - Runtime Identifier</comment>
   </data>
   <data name="MissingRuntimeIdentifierPropertyInProjectFile" xml:space="preserve">

--- a/src/Microsoft.NuGet.Build.Tasks/xlf/Strings.cs.xlf
+++ b/src/Microsoft.NuGet.Build.Tasks/xlf/Strings.cs.xlf
@@ -39,7 +39,7 @@
         <note>0 package id</note>
       </trans-unit>
       <trans-unit id="MissingRuntimeIdentifierInProjectFile">
-        <source>Your project file doesn't list '{0}' as a "RuntimeIdentifier". You should add '{1}' to the "RuntimeIdentifiers" property in your project file (RuntimeIdentifiers should always be the complete list of RIDs supported by the project, regardless of the current configuration, platform or target. Single unconditioned RuntimeIdentifiers property is recommended) and then re-run NuGet restore.</source>
+        <source>Your project file doesn't list '{0}' as a "RuntimeIdentifier". You should add '{1}' to the "RuntimeIdentifiers" property in your project file and then re-run NuGet restore. RuntimeIdentifiers should always be the complete list of RIDs supported by the project, regardless of the current configuration, platform or target. A single unconditioned RuntimeIdentifiers property is recommended.</source>
         <target state="needs-review-translation">Váš soubor projektu neuvádí {0} jako identifikátor RuntimeIdentifier. Měli byste přidat {1} do vlastnosti RuntimeIdentifiers v souboru projektu a pak byste měli znovu spustit obnovení balíčku NuGet.</target>
         <note>0 &amp;1 - Runtime Identifier</note>
       </trans-unit>

--- a/src/Microsoft.NuGet.Build.Tasks/xlf/Strings.cs.xlf
+++ b/src/Microsoft.NuGet.Build.Tasks/xlf/Strings.cs.xlf
@@ -39,8 +39,8 @@
         <note>0 package id</note>
       </trans-unit>
       <trans-unit id="MissingRuntimeIdentifierInProjectFile">
-        <source>Your project file doesn't list '{0}' as a "RuntimeIdentifier". You should add '{1}' to the "RuntimeIdentifiers" property in your project file and then re-run NuGet restore.</source>
-        <target state="translated">Váš soubor projektu neuvádí {0} jako identifikátor RuntimeIdentifier. Měli byste přidat {1} do vlastnosti RuntimeIdentifiers v souboru projektu a pak byste měli znovu spustit obnovení balíčku NuGet.</target>
+        <source>Your project file doesn't list '{0}' as a "RuntimeIdentifier". You should add '{1}' to the "RuntimeIdentifiers" property in your project file (RuntimeIdentifiers should always be the complete list of RIDs supported by the project, regardless of the current configuration, platform or target. Single unconditioned RuntimeIdentifiers property is recommended) and then re-run NuGet restore.</source>
+        <target state="needs-review-translation">Váš soubor projektu neuvádí {0} jako identifikátor RuntimeIdentifier. Měli byste přidat {1} do vlastnosti RuntimeIdentifiers v souboru projektu a pak byste měli znovu spustit obnovení balíčku NuGet.</target>
         <note>0 &amp;1 - Runtime Identifier</note>
       </trans-unit>
       <trans-unit id="MissingRuntimeIdentifierPropertyInProjectFile">

--- a/src/Microsoft.NuGet.Build.Tasks/xlf/Strings.de.xlf
+++ b/src/Microsoft.NuGet.Build.Tasks/xlf/Strings.de.xlf
@@ -39,7 +39,7 @@
         <note>0 package id</note>
       </trans-unit>
       <trans-unit id="MissingRuntimeIdentifierInProjectFile">
-        <source>Your project file doesn't list '{0}' as a "RuntimeIdentifier". You should add '{1}' to the "RuntimeIdentifiers" property in your project file (RuntimeIdentifiers should always be the complete list of RIDs supported by the project, regardless of the current configuration, platform or target. Single unconditioned RuntimeIdentifiers property is recommended) and then re-run NuGet restore.</source>
+        <source>Your project file doesn't list '{0}' as a "RuntimeIdentifier". You should add '{1}' to the "RuntimeIdentifiers" property in your project file and then re-run NuGet restore. RuntimeIdentifiers should always be the complete list of RIDs supported by the project, regardless of the current configuration, platform or target. A single unconditioned RuntimeIdentifiers property is recommended.</source>
         <target state="needs-review-translation">In der Projektdatei wird "{0}" nicht als "RuntimeIdentifier" aufgelistet. Sie müssen der Eigenschaft "RuntimeIdentifiers" in der Projektdatei "{1}" hinzufügen und dann die NuGet-Wiederherstellung erneut ausführen.</target>
         <note>0 &amp;1 - Runtime Identifier</note>
       </trans-unit>

--- a/src/Microsoft.NuGet.Build.Tasks/xlf/Strings.de.xlf
+++ b/src/Microsoft.NuGet.Build.Tasks/xlf/Strings.de.xlf
@@ -39,8 +39,8 @@
         <note>0 package id</note>
       </trans-unit>
       <trans-unit id="MissingRuntimeIdentifierInProjectFile">
-        <source>Your project file doesn't list '{0}' as a "RuntimeIdentifier". You should add '{1}' to the "RuntimeIdentifiers" property in your project file and then re-run NuGet restore.</source>
-        <target state="translated">In der Projektdatei wird "{0}" nicht als "RuntimeIdentifier" aufgelistet. Sie müssen der Eigenschaft "RuntimeIdentifiers" in der Projektdatei "{1}" hinzufügen und dann die NuGet-Wiederherstellung erneut ausführen.</target>
+        <source>Your project file doesn't list '{0}' as a "RuntimeIdentifier". You should add '{1}' to the "RuntimeIdentifiers" property in your project file (RuntimeIdentifiers should always be the complete list of RIDs supported by the project, regardless of the current configuration, platform or target. Single unconditioned RuntimeIdentifiers property is recommended) and then re-run NuGet restore.</source>
+        <target state="needs-review-translation">In der Projektdatei wird "{0}" nicht als "RuntimeIdentifier" aufgelistet. Sie müssen der Eigenschaft "RuntimeIdentifiers" in der Projektdatei "{1}" hinzufügen und dann die NuGet-Wiederherstellung erneut ausführen.</target>
         <note>0 &amp;1 - Runtime Identifier</note>
       </trans-unit>
       <trans-unit id="MissingRuntimeIdentifierPropertyInProjectFile">

--- a/src/Microsoft.NuGet.Build.Tasks/xlf/Strings.es.xlf
+++ b/src/Microsoft.NuGet.Build.Tasks/xlf/Strings.es.xlf
@@ -39,8 +39,8 @@
         <note>0 package id</note>
       </trans-unit>
       <trans-unit id="MissingRuntimeIdentifierInProjectFile">
-        <source>Your project file doesn't list '{0}' as a "RuntimeIdentifier". You should add '{1}' to the "RuntimeIdentifiers" property in your project file and then re-run NuGet restore.</source>
-        <target state="translated">El archivo del proyecto no muestra "{0}" como "RuntimeIdentifier". Debe agregar "{1}" a la propiedad "RuntimeIdentifiers" en el archivo del proyecto y volver a ejecutar la restauración de paquetes NuGet.</target>
+        <source>Your project file doesn't list '{0}' as a "RuntimeIdentifier". You should add '{1}' to the "RuntimeIdentifiers" property in your project file (RuntimeIdentifiers should always be the complete list of RIDs supported by the project, regardless of the current configuration, platform or target. Single unconditioned RuntimeIdentifiers property is recommended) and then re-run NuGet restore.</source>
+        <target state="needs-review-translation">El archivo del proyecto no muestra "{0}" como "RuntimeIdentifier". Debe agregar "{1}" a la propiedad "RuntimeIdentifiers" en el archivo del proyecto y volver a ejecutar la restauración de paquetes NuGet.</target>
         <note>0 &amp;1 - Runtime Identifier</note>
       </trans-unit>
       <trans-unit id="MissingRuntimeIdentifierPropertyInProjectFile">

--- a/src/Microsoft.NuGet.Build.Tasks/xlf/Strings.es.xlf
+++ b/src/Microsoft.NuGet.Build.Tasks/xlf/Strings.es.xlf
@@ -39,7 +39,7 @@
         <note>0 package id</note>
       </trans-unit>
       <trans-unit id="MissingRuntimeIdentifierInProjectFile">
-        <source>Your project file doesn't list '{0}' as a "RuntimeIdentifier". You should add '{1}' to the "RuntimeIdentifiers" property in your project file (RuntimeIdentifiers should always be the complete list of RIDs supported by the project, regardless of the current configuration, platform or target. Single unconditioned RuntimeIdentifiers property is recommended) and then re-run NuGet restore.</source>
+        <source>Your project file doesn't list '{0}' as a "RuntimeIdentifier". You should add '{1}' to the "RuntimeIdentifiers" property in your project file and then re-run NuGet restore. RuntimeIdentifiers should always be the complete list of RIDs supported by the project, regardless of the current configuration, platform or target. A single unconditioned RuntimeIdentifiers property is recommended.</source>
         <target state="needs-review-translation">El archivo del proyecto no muestra "{0}" como "RuntimeIdentifier". Debe agregar "{1}" a la propiedad "RuntimeIdentifiers" en el archivo del proyecto y volver a ejecutar la restauración de paquetes NuGet.</target>
         <note>0 &amp;1 - Runtime Identifier</note>
       </trans-unit>

--- a/src/Microsoft.NuGet.Build.Tasks/xlf/Strings.fr.xlf
+++ b/src/Microsoft.NuGet.Build.Tasks/xlf/Strings.fr.xlf
@@ -39,8 +39,8 @@
         <note>0 package id</note>
       </trans-unit>
       <trans-unit id="MissingRuntimeIdentifierInProjectFile">
-        <source>Your project file doesn't list '{0}' as a "RuntimeIdentifier". You should add '{1}' to the "RuntimeIdentifiers" property in your project file and then re-run NuGet restore.</source>
-        <target state="translated">Votre fichier projet ne liste pas '{0}' comme un "RuntimeIdentifier". Vous devez ajouter '{1}' à la propriété "RuntimeIdentifiers" dans votre fichier projet, puis réexécuter la restauration NuGet.</target>
+        <source>Your project file doesn't list '{0}' as a "RuntimeIdentifier". You should add '{1}' to the "RuntimeIdentifiers" property in your project file (RuntimeIdentifiers should always be the complete list of RIDs supported by the project, regardless of the current configuration, platform or target. Single unconditioned RuntimeIdentifiers property is recommended) and then re-run NuGet restore.</source>
+        <target state="needs-review-translation">Votre fichier projet ne liste pas '{0}' comme un "RuntimeIdentifier". Vous devez ajouter '{1}' à la propriété "RuntimeIdentifiers" dans votre fichier projet, puis réexécuter la restauration NuGet.</target>
         <note>0 &amp;1 - Runtime Identifier</note>
       </trans-unit>
       <trans-unit id="MissingRuntimeIdentifierPropertyInProjectFile">

--- a/src/Microsoft.NuGet.Build.Tasks/xlf/Strings.fr.xlf
+++ b/src/Microsoft.NuGet.Build.Tasks/xlf/Strings.fr.xlf
@@ -39,7 +39,7 @@
         <note>0 package id</note>
       </trans-unit>
       <trans-unit id="MissingRuntimeIdentifierInProjectFile">
-        <source>Your project file doesn't list '{0}' as a "RuntimeIdentifier". You should add '{1}' to the "RuntimeIdentifiers" property in your project file (RuntimeIdentifiers should always be the complete list of RIDs supported by the project, regardless of the current configuration, platform or target. Single unconditioned RuntimeIdentifiers property is recommended) and then re-run NuGet restore.</source>
+        <source>Your project file doesn't list '{0}' as a "RuntimeIdentifier". You should add '{1}' to the "RuntimeIdentifiers" property in your project file and then re-run NuGet restore. RuntimeIdentifiers should always be the complete list of RIDs supported by the project, regardless of the current configuration, platform or target. A single unconditioned RuntimeIdentifiers property is recommended.</source>
         <target state="needs-review-translation">Votre fichier projet ne liste pas '{0}' comme un "RuntimeIdentifier". Vous devez ajouter '{1}' à la propriété "RuntimeIdentifiers" dans votre fichier projet, puis réexécuter la restauration NuGet.</target>
         <note>0 &amp;1 - Runtime Identifier</note>
       </trans-unit>

--- a/src/Microsoft.NuGet.Build.Tasks/xlf/Strings.it.xlf
+++ b/src/Microsoft.NuGet.Build.Tasks/xlf/Strings.it.xlf
@@ -39,8 +39,8 @@
         <note>0 package id</note>
       </trans-unit>
       <trans-unit id="MissingRuntimeIdentifierInProjectFile">
-        <source>Your project file doesn't list '{0}' as a "RuntimeIdentifier". You should add '{1}' to the "RuntimeIdentifiers" property in your project file and then re-run NuGet restore.</source>
-        <target state="translated">Il file di progetto non elenca '{0}' come "RuntimeIdentifier". È necessario aggiungere '{1}' alla proprietà "RuntimeIdentifiers" nel file di progetto e quindi eseguire di nuovo il ripristino di NuGet.</target>
+        <source>Your project file doesn't list '{0}' as a "RuntimeIdentifier". You should add '{1}' to the "RuntimeIdentifiers" property in your project file (RuntimeIdentifiers should always be the complete list of RIDs supported by the project, regardless of the current configuration, platform or target. Single unconditioned RuntimeIdentifiers property is recommended) and then re-run NuGet restore.</source>
+        <target state="needs-review-translation">Il file di progetto non elenca '{0}' come "RuntimeIdentifier". È necessario aggiungere '{1}' alla proprietà "RuntimeIdentifiers" nel file di progetto e quindi eseguire di nuovo il ripristino di NuGet.</target>
         <note>0 &amp;1 - Runtime Identifier</note>
       </trans-unit>
       <trans-unit id="MissingRuntimeIdentifierPropertyInProjectFile">

--- a/src/Microsoft.NuGet.Build.Tasks/xlf/Strings.it.xlf
+++ b/src/Microsoft.NuGet.Build.Tasks/xlf/Strings.it.xlf
@@ -39,7 +39,7 @@
         <note>0 package id</note>
       </trans-unit>
       <trans-unit id="MissingRuntimeIdentifierInProjectFile">
-        <source>Your project file doesn't list '{0}' as a "RuntimeIdentifier". You should add '{1}' to the "RuntimeIdentifiers" property in your project file (RuntimeIdentifiers should always be the complete list of RIDs supported by the project, regardless of the current configuration, platform or target. Single unconditioned RuntimeIdentifiers property is recommended) and then re-run NuGet restore.</source>
+        <source>Your project file doesn't list '{0}' as a "RuntimeIdentifier". You should add '{1}' to the "RuntimeIdentifiers" property in your project file and then re-run NuGet restore. RuntimeIdentifiers should always be the complete list of RIDs supported by the project, regardless of the current configuration, platform or target. A single unconditioned RuntimeIdentifiers property is recommended.</source>
         <target state="needs-review-translation">Il file di progetto non elenca '{0}' come "RuntimeIdentifier". È necessario aggiungere '{1}' alla proprietà "RuntimeIdentifiers" nel file di progetto e quindi eseguire di nuovo il ripristino di NuGet.</target>
         <note>0 &amp;1 - Runtime Identifier</note>
       </trans-unit>

--- a/src/Microsoft.NuGet.Build.Tasks/xlf/Strings.ja.xlf
+++ b/src/Microsoft.NuGet.Build.Tasks/xlf/Strings.ja.xlf
@@ -39,8 +39,8 @@
         <note>0 package id</note>
       </trans-unit>
       <trans-unit id="MissingRuntimeIdentifierInProjectFile">
-        <source>Your project file doesn't list '{0}' as a "RuntimeIdentifier". You should add '{1}' to the "RuntimeIdentifiers" property in your project file and then re-run NuGet restore.</source>
-        <target state="translated">プロジェクト ファイルで '{0}' が 'RuntimeIdentifier' としてリストされていません。プロジェクト ファイルの "RuntimeIdentifiers" プロパティに '{1}' を追加してから、NuGet 復元を再実行してください。</target>
+        <source>Your project file doesn't list '{0}' as a "RuntimeIdentifier". You should add '{1}' to the "RuntimeIdentifiers" property in your project file (RuntimeIdentifiers should always be the complete list of RIDs supported by the project, regardless of the current configuration, platform or target. Single unconditioned RuntimeIdentifiers property is recommended) and then re-run NuGet restore.</source>
+        <target state="needs-review-translation">プロジェクト ファイルで '{0}' が 'RuntimeIdentifier' としてリストされていません。プロジェクト ファイルの "RuntimeIdentifiers" プロパティに '{1}' を追加してから、NuGet 復元を再実行してください。</target>
         <note>0 &amp;1 - Runtime Identifier</note>
       </trans-unit>
       <trans-unit id="MissingRuntimeIdentifierPropertyInProjectFile">

--- a/src/Microsoft.NuGet.Build.Tasks/xlf/Strings.ja.xlf
+++ b/src/Microsoft.NuGet.Build.Tasks/xlf/Strings.ja.xlf
@@ -39,7 +39,7 @@
         <note>0 package id</note>
       </trans-unit>
       <trans-unit id="MissingRuntimeIdentifierInProjectFile">
-        <source>Your project file doesn't list '{0}' as a "RuntimeIdentifier". You should add '{1}' to the "RuntimeIdentifiers" property in your project file (RuntimeIdentifiers should always be the complete list of RIDs supported by the project, regardless of the current configuration, platform or target. Single unconditioned RuntimeIdentifiers property is recommended) and then re-run NuGet restore.</source>
+        <source>Your project file doesn't list '{0}' as a "RuntimeIdentifier". You should add '{1}' to the "RuntimeIdentifiers" property in your project file and then re-run NuGet restore. RuntimeIdentifiers should always be the complete list of RIDs supported by the project, regardless of the current configuration, platform or target. A single unconditioned RuntimeIdentifiers property is recommended.</source>
         <target state="needs-review-translation">プロジェクト ファイルで '{0}' が 'RuntimeIdentifier' としてリストされていません。プロジェクト ファイルの "RuntimeIdentifiers" プロパティに '{1}' を追加してから、NuGet 復元を再実行してください。</target>
         <note>0 &amp;1 - Runtime Identifier</note>
       </trans-unit>

--- a/src/Microsoft.NuGet.Build.Tasks/xlf/Strings.ko.xlf
+++ b/src/Microsoft.NuGet.Build.Tasks/xlf/Strings.ko.xlf
@@ -39,7 +39,7 @@
         <note>0 package id</note>
       </trans-unit>
       <trans-unit id="MissingRuntimeIdentifierInProjectFile">
-        <source>Your project file doesn't list '{0}' as a "RuntimeIdentifier". You should add '{1}' to the "RuntimeIdentifiers" property in your project file (RuntimeIdentifiers should always be the complete list of RIDs supported by the project, regardless of the current configuration, platform or target. Single unconditioned RuntimeIdentifiers property is recommended) and then re-run NuGet restore.</source>
+        <source>Your project file doesn't list '{0}' as a "RuntimeIdentifier". You should add '{1}' to the "RuntimeIdentifiers" property in your project file and then re-run NuGet restore. RuntimeIdentifiers should always be the complete list of RIDs supported by the project, regardless of the current configuration, platform or target. A single unconditioned RuntimeIdentifiers property is recommended.</source>
         <target state="needs-review-translation">프로젝트 파일에 '{0}'이(가) "RuntimeIdentifier"로 나열되지 않습니다. 프로젝트 파일의 "RuntimeIdentifiers" 속성에 '{1}'을(를) 추가한 후 NuGet 복원을 다시 실행해야 합니다.</target>
         <note>0 &amp;1 - Runtime Identifier</note>
       </trans-unit>

--- a/src/Microsoft.NuGet.Build.Tasks/xlf/Strings.ko.xlf
+++ b/src/Microsoft.NuGet.Build.Tasks/xlf/Strings.ko.xlf
@@ -39,8 +39,8 @@
         <note>0 package id</note>
       </trans-unit>
       <trans-unit id="MissingRuntimeIdentifierInProjectFile">
-        <source>Your project file doesn't list '{0}' as a "RuntimeIdentifier". You should add '{1}' to the "RuntimeIdentifiers" property in your project file and then re-run NuGet restore.</source>
-        <target state="translated">프로젝트 파일에 '{0}'이(가) "RuntimeIdentifier"로 나열되지 않습니다. 프로젝트 파일의 "RuntimeIdentifiers" 속성에 '{1}'을(를) 추가한 후 NuGet 복원을 다시 실행해야 합니다.</target>
+        <source>Your project file doesn't list '{0}' as a "RuntimeIdentifier". You should add '{1}' to the "RuntimeIdentifiers" property in your project file (RuntimeIdentifiers should always be the complete list of RIDs supported by the project, regardless of the current configuration, platform or target. Single unconditioned RuntimeIdentifiers property is recommended) and then re-run NuGet restore.</source>
+        <target state="needs-review-translation">프로젝트 파일에 '{0}'이(가) "RuntimeIdentifier"로 나열되지 않습니다. 프로젝트 파일의 "RuntimeIdentifiers" 속성에 '{1}'을(를) 추가한 후 NuGet 복원을 다시 실행해야 합니다.</target>
         <note>0 &amp;1 - Runtime Identifier</note>
       </trans-unit>
       <trans-unit id="MissingRuntimeIdentifierPropertyInProjectFile">

--- a/src/Microsoft.NuGet.Build.Tasks/xlf/Strings.pl.xlf
+++ b/src/Microsoft.NuGet.Build.Tasks/xlf/Strings.pl.xlf
@@ -39,7 +39,7 @@
         <note>0 package id</note>
       </trans-unit>
       <trans-unit id="MissingRuntimeIdentifierInProjectFile">
-        <source>Your project file doesn't list '{0}' as a "RuntimeIdentifier". You should add '{1}' to the "RuntimeIdentifiers" property in your project file (RuntimeIdentifiers should always be the complete list of RIDs supported by the project, regardless of the current configuration, platform or target. Single unconditioned RuntimeIdentifiers property is recommended) and then re-run NuGet restore.</source>
+        <source>Your project file doesn't list '{0}' as a "RuntimeIdentifier". You should add '{1}' to the "RuntimeIdentifiers" property in your project file and then re-run NuGet restore. RuntimeIdentifiers should always be the complete list of RIDs supported by the project, regardless of the current configuration, platform or target. A single unconditioned RuntimeIdentifiers property is recommended.</source>
         <target state="needs-review-translation">Plik projektu nie zawiera elementu „{0}” jako właściwości „RuntimeIdentifier”. Dodaj element „{1}” do właściwości „RuntimeIdentifiers” w pliku projektu, a następnie ponownie uruchom przywracanie pakietu NuGet.</target>
         <note>0 &amp;1 - Runtime Identifier</note>
       </trans-unit>

--- a/src/Microsoft.NuGet.Build.Tasks/xlf/Strings.pl.xlf
+++ b/src/Microsoft.NuGet.Build.Tasks/xlf/Strings.pl.xlf
@@ -39,8 +39,8 @@
         <note>0 package id</note>
       </trans-unit>
       <trans-unit id="MissingRuntimeIdentifierInProjectFile">
-        <source>Your project file doesn't list '{0}' as a "RuntimeIdentifier". You should add '{1}' to the "RuntimeIdentifiers" property in your project file and then re-run NuGet restore.</source>
-        <target state="translated">Plik projektu nie zawiera elementu „{0}” jako właściwości „RuntimeIdentifier”. Dodaj element „{1}” do właściwości „RuntimeIdentifiers” w pliku projektu, a następnie ponownie uruchom przywracanie pakietu NuGet.</target>
+        <source>Your project file doesn't list '{0}' as a "RuntimeIdentifier". You should add '{1}' to the "RuntimeIdentifiers" property in your project file (RuntimeIdentifiers should always be the complete list of RIDs supported by the project, regardless of the current configuration, platform or target. Single unconditioned RuntimeIdentifiers property is recommended) and then re-run NuGet restore.</source>
+        <target state="needs-review-translation">Plik projektu nie zawiera elementu „{0}” jako właściwości „RuntimeIdentifier”. Dodaj element „{1}” do właściwości „RuntimeIdentifiers” w pliku projektu, a następnie ponownie uruchom przywracanie pakietu NuGet.</target>
         <note>0 &amp;1 - Runtime Identifier</note>
       </trans-unit>
       <trans-unit id="MissingRuntimeIdentifierPropertyInProjectFile">

--- a/src/Microsoft.NuGet.Build.Tasks/xlf/Strings.pt-BR.xlf
+++ b/src/Microsoft.NuGet.Build.Tasks/xlf/Strings.pt-BR.xlf
@@ -39,7 +39,7 @@
         <note>0 package id</note>
       </trans-unit>
       <trans-unit id="MissingRuntimeIdentifierInProjectFile">
-        <source>Your project file doesn't list '{0}' as a "RuntimeIdentifier". You should add '{1}' to the "RuntimeIdentifiers" property in your project file (RuntimeIdentifiers should always be the complete list of RIDs supported by the project, regardless of the current configuration, platform or target. Single unconditioned RuntimeIdentifiers property is recommended) and then re-run NuGet restore.</source>
+        <source>Your project file doesn't list '{0}' as a "RuntimeIdentifier". You should add '{1}' to the "RuntimeIdentifiers" property in your project file and then re-run NuGet restore. RuntimeIdentifiers should always be the complete list of RIDs supported by the project, regardless of the current configuration, platform or target. A single unconditioned RuntimeIdentifiers property is recommended.</source>
         <target state="needs-review-translation">O arquivo de projeto não lista '{0}' como um "RuntimeIdentifier". Você deve adicionar '{1}' à propriedade "RuntimeIdentifiers" no arquivo de projeto e, em seguida, executar novamente a restauração do NuGet.</target>
         <note>0 &amp;1 - Runtime Identifier</note>
       </trans-unit>

--- a/src/Microsoft.NuGet.Build.Tasks/xlf/Strings.pt-BR.xlf
+++ b/src/Microsoft.NuGet.Build.Tasks/xlf/Strings.pt-BR.xlf
@@ -39,8 +39,8 @@
         <note>0 package id</note>
       </trans-unit>
       <trans-unit id="MissingRuntimeIdentifierInProjectFile">
-        <source>Your project file doesn't list '{0}' as a "RuntimeIdentifier". You should add '{1}' to the "RuntimeIdentifiers" property in your project file and then re-run NuGet restore.</source>
-        <target state="translated">O arquivo de projeto não lista '{0}' como um "RuntimeIdentifier". Você deve adicionar '{1}' à propriedade "RuntimeIdentifiers" no arquivo de projeto e, em seguida, executar novamente a restauração do NuGet.</target>
+        <source>Your project file doesn't list '{0}' as a "RuntimeIdentifier". You should add '{1}' to the "RuntimeIdentifiers" property in your project file (RuntimeIdentifiers should always be the complete list of RIDs supported by the project, regardless of the current configuration, platform or target. Single unconditioned RuntimeIdentifiers property is recommended) and then re-run NuGet restore.</source>
+        <target state="needs-review-translation">O arquivo de projeto não lista '{0}' como um "RuntimeIdentifier". Você deve adicionar '{1}' à propriedade "RuntimeIdentifiers" no arquivo de projeto e, em seguida, executar novamente a restauração do NuGet.</target>
         <note>0 &amp;1 - Runtime Identifier</note>
       </trans-unit>
       <trans-unit id="MissingRuntimeIdentifierPropertyInProjectFile">

--- a/src/Microsoft.NuGet.Build.Tasks/xlf/Strings.ru.xlf
+++ b/src/Microsoft.NuGet.Build.Tasks/xlf/Strings.ru.xlf
@@ -39,8 +39,8 @@
         <note>0 package id</note>
       </trans-unit>
       <trans-unit id="MissingRuntimeIdentifierInProjectFile">
-        <source>Your project file doesn't list '{0}' as a "RuntimeIdentifier". You should add '{1}' to the "RuntimeIdentifiers" property in your project file and then re-run NuGet restore.</source>
-        <target state="translated">Файл проекта не перечисляет "{0}" как "RuntimeIdentifier". Необходимо добавить "{1}" в свойство "RuntimeIdentifiers" в файле проекта, а затем повторно запустить восстановление NuGet.</target>
+        <source>Your project file doesn't list '{0}' as a "RuntimeIdentifier". You should add '{1}' to the "RuntimeIdentifiers" property in your project file (RuntimeIdentifiers should always be the complete list of RIDs supported by the project, regardless of the current configuration, platform or target. Single unconditioned RuntimeIdentifiers property is recommended) and then re-run NuGet restore.</source>
+        <target state="needs-review-translation">Файл проекта не перечисляет "{0}" как "RuntimeIdentifier". Необходимо добавить "{1}" в свойство "RuntimeIdentifiers" в файле проекта, а затем повторно запустить восстановление NuGet.</target>
         <note>0 &amp;1 - Runtime Identifier</note>
       </trans-unit>
       <trans-unit id="MissingRuntimeIdentifierPropertyInProjectFile">

--- a/src/Microsoft.NuGet.Build.Tasks/xlf/Strings.ru.xlf
+++ b/src/Microsoft.NuGet.Build.Tasks/xlf/Strings.ru.xlf
@@ -39,7 +39,7 @@
         <note>0 package id</note>
       </trans-unit>
       <trans-unit id="MissingRuntimeIdentifierInProjectFile">
-        <source>Your project file doesn't list '{0}' as a "RuntimeIdentifier". You should add '{1}' to the "RuntimeIdentifiers" property in your project file (RuntimeIdentifiers should always be the complete list of RIDs supported by the project, regardless of the current configuration, platform or target. Single unconditioned RuntimeIdentifiers property is recommended) and then re-run NuGet restore.</source>
+        <source>Your project file doesn't list '{0}' as a "RuntimeIdentifier". You should add '{1}' to the "RuntimeIdentifiers" property in your project file and then re-run NuGet restore. RuntimeIdentifiers should always be the complete list of RIDs supported by the project, regardless of the current configuration, platform or target. A single unconditioned RuntimeIdentifiers property is recommended.</source>
         <target state="needs-review-translation">Файл проекта не перечисляет "{0}" как "RuntimeIdentifier". Необходимо добавить "{1}" в свойство "RuntimeIdentifiers" в файле проекта, а затем повторно запустить восстановление NuGet.</target>
         <note>0 &amp;1 - Runtime Identifier</note>
       </trans-unit>

--- a/src/Microsoft.NuGet.Build.Tasks/xlf/Strings.tr.xlf
+++ b/src/Microsoft.NuGet.Build.Tasks/xlf/Strings.tr.xlf
@@ -39,8 +39,8 @@
         <note>0 package id</note>
       </trans-unit>
       <trans-unit id="MissingRuntimeIdentifierInProjectFile">
-        <source>Your project file doesn't list '{0}' as a "RuntimeIdentifier". You should add '{1}' to the "RuntimeIdentifiers" property in your project file and then re-run NuGet restore.</source>
-        <target state="translated">'{0}' tanımlayıcısı, proje dosyanızda "RuntimeIdentifier" olarak listelenmiyor. Proje dosyanızın "RuntimeIdentifiers" özelliğine '{1}' tanımlayıcısını eklemeniz ve sonra NuGet geri yükleme işlemini yeniden çalıştırmanız gerekiyor.</target>
+        <source>Your project file doesn't list '{0}' as a "RuntimeIdentifier". You should add '{1}' to the "RuntimeIdentifiers" property in your project file (RuntimeIdentifiers should always be the complete list of RIDs supported by the project, regardless of the current configuration, platform or target. Single unconditioned RuntimeIdentifiers property is recommended) and then re-run NuGet restore.</source>
+        <target state="needs-review-translation">'{0}' tanımlayıcısı, proje dosyanızda "RuntimeIdentifier" olarak listelenmiyor. Proje dosyanızın "RuntimeIdentifiers" özelliğine '{1}' tanımlayıcısını eklemeniz ve sonra NuGet geri yükleme işlemini yeniden çalıştırmanız gerekiyor.</target>
         <note>0 &amp;1 - Runtime Identifier</note>
       </trans-unit>
       <trans-unit id="MissingRuntimeIdentifierPropertyInProjectFile">

--- a/src/Microsoft.NuGet.Build.Tasks/xlf/Strings.tr.xlf
+++ b/src/Microsoft.NuGet.Build.Tasks/xlf/Strings.tr.xlf
@@ -39,7 +39,7 @@
         <note>0 package id</note>
       </trans-unit>
       <trans-unit id="MissingRuntimeIdentifierInProjectFile">
-        <source>Your project file doesn't list '{0}' as a "RuntimeIdentifier". You should add '{1}' to the "RuntimeIdentifiers" property in your project file (RuntimeIdentifiers should always be the complete list of RIDs supported by the project, regardless of the current configuration, platform or target. Single unconditioned RuntimeIdentifiers property is recommended) and then re-run NuGet restore.</source>
+        <source>Your project file doesn't list '{0}' as a "RuntimeIdentifier". You should add '{1}' to the "RuntimeIdentifiers" property in your project file and then re-run NuGet restore. RuntimeIdentifiers should always be the complete list of RIDs supported by the project, regardless of the current configuration, platform or target. A single unconditioned RuntimeIdentifiers property is recommended.</source>
         <target state="needs-review-translation">'{0}' tanımlayıcısı, proje dosyanızda "RuntimeIdentifier" olarak listelenmiyor. Proje dosyanızın "RuntimeIdentifiers" özelliğine '{1}' tanımlayıcısını eklemeniz ve sonra NuGet geri yükleme işlemini yeniden çalıştırmanız gerekiyor.</target>
         <note>0 &amp;1 - Runtime Identifier</note>
       </trans-unit>

--- a/src/Microsoft.NuGet.Build.Tasks/xlf/Strings.zh-Hans.xlf
+++ b/src/Microsoft.NuGet.Build.Tasks/xlf/Strings.zh-Hans.xlf
@@ -39,7 +39,7 @@
         <note>0 package id</note>
       </trans-unit>
       <trans-unit id="MissingRuntimeIdentifierInProjectFile">
-        <source>Your project file doesn't list '{0}' as a "RuntimeIdentifier". You should add '{1}' to the "RuntimeIdentifiers" property in your project file (RuntimeIdentifiers should always be the complete list of RIDs supported by the project, regardless of the current configuration, platform or target. Single unconditioned RuntimeIdentifiers property is recommended) and then re-run NuGet restore.</source>
+        <source>Your project file doesn't list '{0}' as a "RuntimeIdentifier". You should add '{1}' to the "RuntimeIdentifiers" property in your project file and then re-run NuGet restore. RuntimeIdentifiers should always be the complete list of RIDs supported by the project, regardless of the current configuration, platform or target. A single unconditioned RuntimeIdentifiers property is recommended.</source>
         <target state="needs-review-translation">项目文件未将“{0}”列为 "RuntimeIdentifier"。应在项目文件的 "RuntimeIdentifiers" 属性中添加“{1}”，然后重新运行 NuGet 还原。</target>
         <note>0 &amp;1 - Runtime Identifier</note>
       </trans-unit>

--- a/src/Microsoft.NuGet.Build.Tasks/xlf/Strings.zh-Hans.xlf
+++ b/src/Microsoft.NuGet.Build.Tasks/xlf/Strings.zh-Hans.xlf
@@ -39,8 +39,8 @@
         <note>0 package id</note>
       </trans-unit>
       <trans-unit id="MissingRuntimeIdentifierInProjectFile">
-        <source>Your project file doesn't list '{0}' as a "RuntimeIdentifier". You should add '{1}' to the "RuntimeIdentifiers" property in your project file and then re-run NuGet restore.</source>
-        <target state="translated">项目文件未将“{0}”列为 "RuntimeIdentifier"。应在项目文件的 "RuntimeIdentifiers" 属性中添加“{1}”，然后重新运行 NuGet 还原。</target>
+        <source>Your project file doesn't list '{0}' as a "RuntimeIdentifier". You should add '{1}' to the "RuntimeIdentifiers" property in your project file (RuntimeIdentifiers should always be the complete list of RIDs supported by the project, regardless of the current configuration, platform or target. Single unconditioned RuntimeIdentifiers property is recommended) and then re-run NuGet restore.</source>
+        <target state="needs-review-translation">项目文件未将“{0}”列为 "RuntimeIdentifier"。应在项目文件的 "RuntimeIdentifiers" 属性中添加“{1}”，然后重新运行 NuGet 还原。</target>
         <note>0 &amp;1 - Runtime Identifier</note>
       </trans-unit>
       <trans-unit id="MissingRuntimeIdentifierPropertyInProjectFile">

--- a/src/Microsoft.NuGet.Build.Tasks/xlf/Strings.zh-Hant.xlf
+++ b/src/Microsoft.NuGet.Build.Tasks/xlf/Strings.zh-Hant.xlf
@@ -39,8 +39,8 @@
         <note>0 package id</note>
       </trans-unit>
       <trans-unit id="MissingRuntimeIdentifierInProjectFile">
-        <source>Your project file doesn't list '{0}' as a "RuntimeIdentifier". You should add '{1}' to the "RuntimeIdentifiers" property in your project file and then re-run NuGet restore.</source>
-        <target state="translated">您的專案檔未將 '{0}' 列為 "RuntimeIdentifier"。您應該將 '{1}' 新增到專案檔中的 "RuntimeIdentifiers" 屬性，然後重新執行 NuGet 還原。</target>
+        <source>Your project file doesn't list '{0}' as a "RuntimeIdentifier". You should add '{1}' to the "RuntimeIdentifiers" property in your project file (RuntimeIdentifiers should always be the complete list of RIDs supported by the project, regardless of the current configuration, platform or target. Single unconditioned RuntimeIdentifiers property is recommended) and then re-run NuGet restore.</source>
+        <target state="needs-review-translation">您的專案檔未將 '{0}' 列為 "RuntimeIdentifier"。您應該將 '{1}' 新增到專案檔中的 "RuntimeIdentifiers" 屬性，然後重新執行 NuGet 還原。</target>
         <note>0 &amp;1 - Runtime Identifier</note>
       </trans-unit>
       <trans-unit id="MissingRuntimeIdentifierPropertyInProjectFile">

--- a/src/Microsoft.NuGet.Build.Tasks/xlf/Strings.zh-Hant.xlf
+++ b/src/Microsoft.NuGet.Build.Tasks/xlf/Strings.zh-Hant.xlf
@@ -39,7 +39,7 @@
         <note>0 package id</note>
       </trans-unit>
       <trans-unit id="MissingRuntimeIdentifierInProjectFile">
-        <source>Your project file doesn't list '{0}' as a "RuntimeIdentifier". You should add '{1}' to the "RuntimeIdentifiers" property in your project file (RuntimeIdentifiers should always be the complete list of RIDs supported by the project, regardless of the current configuration, platform or target. Single unconditioned RuntimeIdentifiers property is recommended) and then re-run NuGet restore.</source>
+        <source>Your project file doesn't list '{0}' as a "RuntimeIdentifier". You should add '{1}' to the "RuntimeIdentifiers" property in your project file and then re-run NuGet restore. RuntimeIdentifiers should always be the complete list of RIDs supported by the project, regardless of the current configuration, platform or target. A single unconditioned RuntimeIdentifiers property is recommended.</source>
         <target state="needs-review-translation">您的專案檔未將 '{0}' 列為 "RuntimeIdentifier"。您應該將 '{1}' 新增到專案檔中的 "RuntimeIdentifiers" 屬性，然後重新執行 NuGet 還原。</target>
         <note>0 &amp;1 - Runtime Identifier</note>
       </trans-unit>


### PR DESCRIPTION
### Context

Current error might get confusing in some cases. Especially when users are trying to st value of `RuntimeIdentifiers` conditionally based on configurations.

### Changes made

Just adjusting the error message - stealing the finding and formulation from @rainersigwald  - explicitly mentioning the `RuntimeIdentifiers` is expected to contain all supported RIDs

