### PR TITLE
Always capture build logs

### DIFF
--- a/build/azure-pipelines-ci.yml
+++ b/build/azure-pipelines-ci.yml
@@ -41,10 +41,10 @@ jobs:
     - task: PublishBuildArtifacts@1
       inputs:
         PathtoPublish: '$(Build.SourcesDirectory)\artifacts\log\$(_configuration)'
-        ArtifactName: '$(_configuration) unit test logs'
+        ArtifactName: '$(_configuration) Logs'
         publishLocation: Container
       continueOnError: true
-      condition: failed()
+      condition: always()
     - task: PublishBuildArtifacts@1
       inputs:
         PathtoPublish: '$(Build.SourcesDirectory)\artifacts\bin'
@@ -55,7 +55,7 @@ jobs:
     - task: PublishBuildArtifacts@1
       inputs:
         PathtoPublish: '$(Build.SourcesDirectory)\artifacts\TestResults\$(_configuration)'
-        ArtifactName: '$(_configuration) Test Result Logs'
+        ArtifactName: '$(_configuration) Test Results'
         publishLocation: Container
       continueOnError: true
       condition: failed()


### PR DESCRIPTION
Currently we don't publish any build artifacts if the build succeeds. While we don't generally need to keep the binaries, build logs, or test logs around I plan on making changes to how the repo builds and it would be useful to have at least the .binlog files.

Also update the artifact names to correctly describe what they contain.