### PR TITLE
Update the build pool

### DIFF
--- a/build/official.yml
+++ b/build/official.yml
@@ -20,7 +20,7 @@ jobs:
       LclPackageId: 'LCL-JUNO-PROD-NBUILDTASKS'
 - job: Build
   pool:
-    name: VSEngSS-MicroBuild2019-1ES
+    name: VSEngSS-MicroBuild2022-1ES
     demands: Cmd
     timeoutInMinutes: 90
   steps:


### PR DESCRIPTION
Update the build pool to one based on VS 2022 instead of VS 2019.