### PR TITLE
Add DefaultDllImportSearchPaths

### DIFF
--- a/src/Microsoft.NuGet.Build.Tasks/GlobalAssemblyInfo.cs
+++ b/src/Microsoft.NuGet.Build.Tasks/GlobalAssemblyInfo.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved. 
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information. 
+
 using System.Runtime.InteropServices;
 
 // Ensure P/Invokes from within this assembly only load libraries from trusted and safe paths.

--- a/src/Microsoft.NuGet.Build.Tasks/GlobalAssemblyInfo.cs
+++ b/src/Microsoft.NuGet.Build.Tasks/GlobalAssemblyInfo.cs
@@ -1,0 +1,4 @@
+using System.Runtime.InteropServices;
+
+// Ensure P/Invokes from within this assembly only load libraries from trusted and safe paths.
+[assembly: DefaultDllImportSearchPaths(DllImportSearchPath.SafeDirectories)]


### PR DESCRIPTION
Related to [AB#1853770](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1853770).

Use the `DefaultDllImportSearchPaths` attribute to ensure that P/Invokes (if any) from within this assembly only load native libraries from trusted and safe paths.