### PR TITLE
Fix nullref in ResolveNuGetPackageAssets when $(Language) is not set

### DIFF
--- a/src/Microsoft.NuGet.Build.Tasks/ResolveNuGetPackageAssets.cs
+++ b/src/Microsoft.NuGet.Build.Tasks/ResolveNuGetPackageAssets.cs
@@ -471,7 +471,7 @@ namespace Microsoft.NuGet.Build.Tasks
             expectedLanguage = expectedLanguage == "C#" ? "cs" : expectedLanguage;
             unExpectedLanguage = unExpectedLanguage == "C#" ? "cs" : unExpectedLanguage;
 
-            return (ProjectLanguage.Equals(expectedProjectLanguage, StringComparison.OrdinalIgnoreCase)) &&
+            return (string.Equals(ProjectLanguage, expectedProjectLanguage, StringComparison.OrdinalIgnoreCase)) &&
                             (file.Split('/').Any(x => x.Equals(ProjectLanguage, StringComparison.OrdinalIgnoreCase)) ||
                             !file.Split('/').Any(x => x.Equals(unExpectedLanguage, StringComparison.OrdinalIgnoreCase)));
         }


### PR DESCRIPTION
Fixes #73

Tested against an internal project. Ping me offline if you want details about the specific repro I validated against.