### PR TITLE
Remove incorrect signing check

### DIFF
--- a/build/analyze-compliance.yml
+++ b/build/analyze-compliance.yml
@@ -10,16 +10,6 @@ parameters:
 # - InferSharp: https://dev.azure.com/securitytools/SecurityIntegration/_wiki/wikis/Guardian/1638/InferSharp-Usage
 # - CodeQL: https://eng.ms/docs/security-compliance-identity-and-management-scim/security/azure-security/cloudai-security-fundamentals-engineering/security-integration/guardian-wiki/sdl-azdo-extension/codeql-build-task
 steps:
-# Verify the loose DLLs are signed appropriately.
-# Note: This task takes ~3 minutes only because it is the first Guardian task in this job. So, it installs the Guardian components so the other tasks don't have to.
-# YAML reference: https://eng.ms/docs/security-compliance-identity-and-management-scim/security/azure-security/cloudai-security-fundamentals-engineering/security-integration/guardian-wiki/sdl-azdo-extension/code-signing-validation-build-task#v1-preview
-- task: CodeSign@1
-  displayName: Verify Signed DLLs
-  inputs:
-    Path: $(Build.SourcesDirectory)/artifacts/DLLs/
-    # Glob Format: https://dev.azure.com/securitytools/SecurityIntegration/_wiki/wikis/Guardian/1378/Glob-Format
-    Targets: '**.dll'
-  condition: succeededOrFailed()
 
 # Scan for the use of undocumented APIs.
 # YAML reference: https://eng.ms/docs/security-compliance-identity-and-management-scim/security/azure-security/cloudai-security-fundamentals-engineering/security-integration/guardian-wiki/sdl-azdo-extension/apiscan-build-task#v2


### PR DESCRIPTION
[pipeline run](https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=9487057&view=results)

This code signing validation is incompatible with Arcade pipelines. It is causing `CodeSign.MissingSigningCert` on all of the `.dll` that are in fact signed. This is because this code sign validation doesn't work with how this Arcade repo is signed. Thus, this code sign validation needs to be removed because it is an invalid check.

Signing is done here with the singing plugin and during build here: https://github.com/dotnet/NuGet.BuildTasks/blob/ffb0d794b8ddf3c7f227f305e4f5b73cd417fe8c/eng/common/templates-official/job/job.yml#L131 https://github.com/dotnet/NuGet.BuildTasks/blob/ffb0d794b8ddf3c7f227f305e4f5b73cd417fe8c/eng/common/build.ps1#L60

I have manually verified that the `.dll`s are in fact being signed. For example, we can see that the `Microsoft.NuGet.Build.Tasks.dll` is being signed here:
![image](https://github.com/dotnet/NuGet.BuildTasks/assets/111816896/d3027a9c-6010-45ad-b511-7737535efac7)
![screenshot](https://github.com/dotnet/NuGet.BuildTasks/assets/111816896/af56b873-a959-4a7d-bdb1-7d464e429a85)



Originally, this validation was copied over from a non-Arcade pipeline during the 1ES pipeline migration. In the future, we want to use Arcade signing validation in our pipeline; I created #180 to track.