### PR TITLE
Add NuGetPackTargets import to ImportAfter.targets

### DIFF
--- a/src/Microsoft.NuGet.Build.Tasks/ImportBeforeAfter/Microsoft.NuGet.ImportAfter.targets
+++ b/src/Microsoft.NuGet.Build.Tasks/ImportBeforeAfter/Microsoft.NuGet.ImportAfter.targets
@@ -12,6 +12,8 @@ Copyright (c) .NET Foundation. All rights reserved.
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <NuGetTargets Condition="'$(NuGetTargets)'==''">$(MSBuildExtensionsPath)\Microsoft\NuGet\$(VisualStudioVersion)\Microsoft.NuGet.targets</NuGetTargets>
+    <NuGetPackTargets Condition="'$(NuGetPackTargets)'==''">$(MSBuildExtensionsPath)\..\Common7\IDE\CommonExtensions\Microsoft\NuGet\NuGet.Build.Tasks.Pack.targets</NuGetPackTargets>
   </PropertyGroup>
   <Import Condition="Exists('$(NuGetTargets)') and '$(SkipImportNuGetBuildTargets)' != 'true'" Project="$(NuGetTargets)" />
+  <Import Condition="Exists('$(NuGetPackTargets)') And '$(SkipImportNuGetPackTargets)' != 'true' and '$(UsingMicrosoftNetSdk)' != 'true'" Project="$(NuGetPackTargets)" />
 </Project>


### PR DESCRIPTION
Fixes: https://github.com/NuGet/Home/issues/14519

NuGet is making pack available in VS, so no longer need to reference the NuGet.Build.Tasks.Pack package, just like SDK style projects.

I tried double clicking the vsix that this repo creates on local build, but it didn't work for me. So, I tested by editing the file in the VS install directory with the same contents. Running the pack target on a solution with legacy csproj using packages.config, a legacy csproj using PackageReference, an SDK style project, and a native C++ project caused the two PackageReference projects to create a nupkg, and the other projects had no-op, hopefully allowing solutions that have multiple packagse to be packed to simply run pack on the solution file.